### PR TITLE
v.0.0.7

### DIFF
--- a/concurrencpp/src/results/constants.h
+++ b/concurrencpp/src/results/constants.h
@@ -55,27 +55,27 @@ namespace concurrencpp::details::consts {
 		"result::resolve_via() - given executor is null.";
 
 	inline const char* k_result_awaitable_error_msg =
-		"concurrencpp::awaitable_type<type>::await_suspend - awaitable is empty.";
+		"concurrencpp::awaitable_type<type>::await_suspend() - awaitable is empty.";
 
 	inline const char* k_result_resolver_error_msg =
-		"result_resolver<type>::await_suspend - awaitable is empty.";
+		"result_resolver<type>::await_suspend() - awaitable is empty.";
 
 	inline const char* k_executor_exception_error_msg =
 		"concurrencpp::result - an exception was thrown while trying to enqueue result continuation.";
 
 
 	inline const char* k_make_exceptional_result_exception_null_error_msg =
-		"make_exception_result - given exception_ptr is null.";
+		"make_exception_result() - given exception_ptr is null.";
 
 
 	inline const char* k_when_all_empty_result_error_msg =
-		"concurrencpp::when_all - one of the result objects is empty.";
+		"concurrencpp::when_all() - one of the result objects is empty.";
 
 	inline const char* k_when_any_empty_result_error_msg =
-		"concurrencpp::when_any - one of the result objects is empty.";
+		"concurrencpp::when_any() - one of the result objects is empty.";
 
 	inline const char* k_when_any_empty_range_error_msg =
-		"concurrencpp::when_any - given range contains no elements.";
+		"concurrencpp::when_any() - given range contains no elements.";
 }
 
 #endif

--- a/concurrencpp/src/timers/timer.cpp
+++ b/concurrencpp/src/timers/timer.cpp
@@ -51,14 +51,14 @@ void timer::throw_if_empty(const char* error_message) const {
 	throw concurrencpp::errors::empty_timer(error_message);
 }
 
-size_t timer::get_due_time() const {
+std::chrono::milliseconds timer::get_due_time() const {
 	throw_if_empty(details::consts::k_timer_empty_get_due_time_err_msg);
-	return m_state->get_due_time();
+	return std::chrono::milliseconds(m_state->get_due_time());
 }
 
-size_t timer::get_frequency() const {
+std::chrono::milliseconds timer::get_frequency() const {
 	throw_if_empty(details::consts::k_timer_empty_get_frequency_err_msg);
-	return m_state->get_frequency();
+	return std::chrono::milliseconds(m_state->get_frequency());
 }
 
 std::shared_ptr<concurrencpp::executor> timer::get_executor() const {
@@ -86,9 +86,9 @@ void timer::cancel() {
 	timer_queue->remove_timer(std::move(state));
 }
 
-void timer::set_frequency(size_t new_frequency) {
+void timer::set_frequency(std::chrono::milliseconds new_frequency) {
 	throw_if_empty(details::consts::k_timer_empty_set_frequency_err_msg);
-	return m_state->set_new_frequency(new_frequency);
+	return m_state->set_new_frequency(new_frequency.count());
 }
 
 timer& timer::operator = (timer&& rhs) noexcept {

--- a/concurrencpp/src/timers/timer.h
+++ b/concurrencpp/src/timers/timer.h
@@ -124,12 +124,12 @@ namespace concurrencpp {
 
 		void cancel();
 
-		size_t get_due_time() const;
+		std::chrono::milliseconds get_due_time() const;
 		std::shared_ptr<executor> get_executor() const;
 		std::weak_ptr<timer_queue> get_timer_queue() const;
 
-		size_t get_frequency() const;
-		void set_frequency(size_t new_frequency);
+		std::chrono::milliseconds get_frequency() const;
+		void set_frequency(std::chrono::milliseconds new_frequency);
 
 		operator bool() const noexcept {
 			return static_cast<bool>(m_state);

--- a/concurrencpp/src/timers/timer_queue.cpp
+++ b/concurrencpp/src/timers/timer_queue.cpp
@@ -227,7 +227,7 @@ void timer_queue::ensure_worker_thread(std::unique_lock<std::mutex>& lock) {
     });
 }
 
-concurrencpp::result<void> timer_queue::make_delay_object(size_t due_time, std::shared_ptr<executor> executor) {
+concurrencpp::result<void> timer_queue::make_delay_object(std::chrono::milliseconds due_time, std::shared_ptr<executor> executor) {
     if (!static_cast<bool>(executor)) {
         throw std::invalid_argument(details::consts::k_timer_queue_make_delay_object_executor_null_err_msg);
     }
@@ -236,7 +236,7 @@ concurrencpp::result<void> timer_queue::make_delay_object(size_t due_time, std::
     auto task = promise.get_result();
 
     make_timer_impl(
-        due_time,
+        due_time.count(),
         0,
         std::move(executor),
         true,

--- a/concurrencpp/src/timers/timer_queue.h
+++ b/concurrencpp/src/timers/timer_queue.h
@@ -88,29 +88,10 @@ namespace concurrencpp {
 		void shutdown() noexcept;
 		bool shutdown_requested() const noexcept;
 
-		template<class callable_type>
-		timer make_timer(
-			size_t due_time,
-			size_t frequency,
-			std::shared_ptr<concurrencpp::executor> executor,
-			callable_type&& callable) {
-
-			if (!static_cast<bool>(executor)) {
-				throw std::invalid_argument(details::consts::k_timer_queue_make_timer_executor_null_err_msg);
-			}
-
-			return make_timer_impl(
-				due_time,
-				frequency,
-				std::move(executor),
-				false,
-				std::forward<callable_type>(callable));
-		}
-
 		template<class callable_type, class ... argumet_types>
 		timer make_timer(
-			size_t due_time,
-			size_t frequency,
+			std::chrono::milliseconds due_time,
+			std::chrono::milliseconds frequency,
 			std::shared_ptr<concurrencpp::executor> executor,
 			callable_type&& callable,
 			argumet_types&& ... arguments) {
@@ -120,8 +101,8 @@ namespace concurrencpp {
 			}
 
 			return make_timer_impl(
-				due_time,
-				frequency,
+				due_time.count(),
+				frequency.count(),
 				std::move(executor),
 				false,
 				details::bind(
@@ -129,27 +110,9 @@ namespace concurrencpp {
 					std::forward<argumet_types>(arguments)...));
 		}
 
-		template<class callable_type>
-		timer make_one_shot_timer(
-			size_t due_time,
-			std::shared_ptr<concurrencpp::executor> executor,
-			callable_type&& callable) {
-
-			if (!static_cast<bool>(executor)) {
-				throw std::invalid_argument(details::consts::k_timer_queue_make_oneshot_timer_executor_null_err_msg);
-			}
-
-			return make_timer_impl(
-				due_time,
-				0,
-				std::move(executor),
-				true,
-				std::forward<callable_type>(callable));
-		}
-
 		template<class callable_type, class ... argumet_types>
 		timer make_one_shot_timer(
-			size_t due_time,
+			std::chrono::milliseconds due_time,
 			std::shared_ptr<concurrencpp::executor> executor,
 			callable_type&& callable,
 			argumet_types&& ... arguments) {
@@ -159,7 +122,7 @@ namespace concurrencpp {
 			}
 
 			return make_timer_impl(
-				due_time,
+				due_time.count(),
 				0,
 				std::move(executor),
 				true,
@@ -168,7 +131,7 @@ namespace concurrencpp {
 					std::forward<argumet_types>(arguments)...));
 		}
 
-		result<void> make_delay_object(size_t due_time, std::shared_ptr<concurrencpp::executor> executor);
+		result<void> make_delay_object(std::chrono::milliseconds due_time, std::shared_ptr<concurrencpp::executor> executor);
 	};
 }
 

--- a/concurrencpp/src/utils/bind.h
+++ b/concurrencpp/src/utils/bind.h
@@ -5,6 +5,11 @@
 #include <type_traits>
 
 namespace concurrencpp::details {
+	template<class callable_type>
+	auto bind(callable_type&& callable) {
+		return std::forward<callable_type>(callable); //no arguments to bind
+	}
+
 	template<class callable_type, class ... argument_types>
 	auto bind(callable_type&& callable, argument_types&& ... arguments) {
 		constexpr static auto inti = std::is_nothrow_invocable_v<callable_type, argument_types...>;

--- a/examples/process_monitor/src/main.cpp
+++ b/examples/process_monitor/src/main.cpp
@@ -12,6 +12,8 @@
 
 #include <iostream>
 
+using namespace std::chrono_literals;
+
 class process_stat_printer {
 
 private:
@@ -37,8 +39,8 @@ int main(int, const char**) {
 	auto timer_queue = runtime.timer_queue();
 	auto thread_pool_executor = runtime.thread_pool_executor();
 	auto timer = timer_queue->make_timer(
-		2500,
-		2500,
+		2500ms,
+		2500ms,
 		thread_pool_executor,
 		process_stat_printer());
 

--- a/tests/tests/timer_tests/timer_queue_tests.cpp
+++ b/tests/tests/timer_tests/timer_queue_tests.cpp
@@ -8,6 +8,8 @@
 
 #include <chrono>
 
+using namespace std::chrono_literals;
+
 namespace concurrencpp::tests {
 	void test_timer_queue_make_timer();
 	void test_timer_queue_make_oneshot_timer();
@@ -19,7 +21,7 @@ void concurrencpp::tests::test_timer_queue_make_timer() {
 	assert_false(timer_queue->shutdown_requested());
 
 	assert_throws_with_error_message<std::invalid_argument>([timer_queue] {
-		timer_queue->make_timer(100, 100, {}, [] {});
+		timer_queue->make_timer(100ms, 100ms, {}, [] {});
 		},
 		concurrencpp::details::consts::k_timer_queue_make_timer_executor_null_err_msg);
 
@@ -28,7 +30,7 @@ void concurrencpp::tests::test_timer_queue_make_timer() {
 
 	assert_throws_with_error_message<errors::timer_queue_shutdown>([timer_queue] {
 		auto inline_executor = std::make_shared<concurrencpp::inline_executor>();
-		timer_queue->make_timer(100, 100, inline_executor, [] {});
+		timer_queue->make_timer(100ms, 100ms, inline_executor, [] {});
 		},
 		concurrencpp::details::consts::k_timer_queue_shutdown_err_msg);
 }
@@ -38,7 +40,7 @@ void concurrencpp::tests::test_timer_queue_make_oneshot_timer() {
 	assert_false(timer_queue->shutdown_requested());
 
 	assert_throws_with_error_message<std::invalid_argument>([timer_queue] {
-		timer_queue->make_one_shot_timer(100, {}, [] {});
+		timer_queue->make_one_shot_timer(100ms, {}, [] {});
 		},
 		concurrencpp::details::consts::k_timer_queue_make_oneshot_timer_executor_null_err_msg);
 
@@ -47,7 +49,7 @@ void concurrencpp::tests::test_timer_queue_make_oneshot_timer() {
 
 	assert_throws_with_error_message<errors::timer_queue_shutdown>([timer_queue] {
 		auto inline_executor = std::make_shared<concurrencpp::inline_executor>();
-		timer_queue->make_one_shot_timer(100, inline_executor, [] {});
+		timer_queue->make_one_shot_timer(100ms, inline_executor, [] {});
 		},
 		concurrencpp::details::consts::k_timer_queue_shutdown_err_msg);
 }
@@ -57,7 +59,7 @@ void concurrencpp::tests::test_timer_queue_make_delay_object() {
 	assert_false(timer_queue->shutdown_requested());
 
 	assert_throws_with_error_message<std::invalid_argument>([timer_queue] {
-		timer_queue->make_delay_object(100, {});
+		timer_queue->make_delay_object(100ms, {});
 		},
 		concurrencpp::details::consts::k_timer_queue_make_delay_object_executor_null_err_msg);
 
@@ -66,17 +68,17 @@ void concurrencpp::tests::test_timer_queue_make_delay_object() {
 
 	assert_throws_with_error_message<errors::timer_queue_shutdown>([timer_queue] {
 		auto inline_executor = std::make_shared<concurrencpp::inline_executor>();
-		timer_queue->make_delay_object(100, inline_executor);
+		timer_queue->make_delay_object(100ms, inline_executor);
 		},
 		concurrencpp::details::consts::k_timer_queue_shutdown_err_msg);
 }
 
 void concurrencpp::tests::test_timer_queue() {
-	tester tester("timer_queue test");
+	tester test("timer_queue test");
 
-	tester.add_step("make_timer", test_timer_queue_make_timer);
-	tester.add_step("make_oneshot_timer", test_timer_queue_make_timer);
-	tester.add_step("make_delay_object", test_timer_queue_make_delay_object);
+	test.add_step("make_timer", test_timer_queue_make_timer);
+	test.add_step("make_oneshot_timer", test_timer_queue_make_timer);
+	test.add_step("make_delay_object", test_timer_queue_make_delay_object);
 
-	tester.launch_test();
+	test.launch_test();
 }


### PR DESCRIPTION
* when_all safer implementation (I suspect a bug in Clang codegen for coroutines)
* result_core::publish_result doesn't move the consumer context
* timer queue only accepts callables + args. bind returns the same callable if no arguments were given
* timer uses std::chrono::milliseconds instead of size_t
* error messages style unification