### PR TITLE
Simplify test lists

### DIFF
--- a/cmake/concurrencppInjectTSAN.cmake
+++ b/cmake/concurrencppInjectTSAN.cmake
@@ -1,9 +1,0 @@
-# Inject sanitizer flag as a build requirement
-#
-macro(add_library TARGET)
-  _add_library(${ARGV})
-
-  if("${TARGET}" STREQUAL "concurrencpp")
-    target_compile_options(concurrencpp PRIVATE -fsanitize=thread)
-  endif()
-endmacro()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,11 @@ option(ENABLE_THREAD_SANITIZER "\
 Build concurrencpp with LLVM thread sanitizer. \
 Does not have an effect if the compiler is not Clang based." OFF)
 
+set(use_tsan NO)
+if(ENABLE_THREAD_SANITIZER AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(use_tsan YES)
+endif()
+
 # Enable warnings from includes
 set(concurrencpp_INCLUDE_WITHOUT_SYSTEM ON CACHE INTERNAL "")
 
@@ -17,7 +22,7 @@ include(FetchContent)
 FetchContent_Declare(concurrencpp SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 FetchContent_MakeAvailable(concurrencpp)
 
-if(ENABLE_THREAD_SANITIZER AND CXX_COMPILER_ID MATCHES "Clang")
+if(use_tsan)
   target_compile_options(concurrencpp PRIVATE -fsanitize=thread)
 endif()
 
@@ -80,7 +85,7 @@ endfunction()
 
 temp_test(dummy main ${test_headers} ${test_sources})
 
-if(NOT ENABLE_THREAD_SANITIZER)
+if(NOT use_tsan)
   return()
 endif()
 
@@ -127,7 +132,7 @@ endfunction()
 
 # TODO: add tests
 
-if(NOT ENABLE_THREAD_SANITIZER)
+if(NOT use_tsan)
   return()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,20 +10,16 @@ option(ENABLE_THREAD_SANITIZER "\
 Build concurrencpp with LLVM thread sanitizer. \
 Does not have an effect if the compiler is not Clang based." OFF)
 
-if(ENABLE_THREAD_SANITIZER AND CXX_COMPILER_ID MATCHES "Clang")
-  # Instead of polluting the lists file, we inject a command definition
-  # override that will apply the sanitizer flag
-  set(CMAKE_PROJECT_concurrencpp_INCLUDE
-          "${CMAKE_CURRENT_LIST_DIR}/../cmake/concurrencppInjectTSAN.cmake"
-          CACHE INTERNAL "")
-endif()
-
 # Enable warnings from includes
 set(concurrencpp_INCLUDE_WITHOUT_SYSTEM ON CACHE INTERNAL "")
 
 include(FetchContent)
 FetchContent_Declare(concurrencpp SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 FetchContent_MakeAvailable(concurrencpp)
+
+if(ENABLE_THREAD_SANITIZER AND CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(concurrencpp PRIVATE -fsanitize=thread)
+endif()
 
 # ---- Test ----
 


### PR DESCRIPTION
Sorry for the rapid fire PRs!  
However, I found a simpler way to apply the sanitizer flag, also `CXX_COMPILER_ID` is only usable in generator expressions.