### PR TITLE
fix: usage of uninitialized callback in constexpr function

### DIFF
--- a/include/concurrencpp/task.h
+++ b/include/concurrencpp/task.h
@@ -89,8 +89,8 @@ namespace concurrencpp::details {
         }
 
         static constexpr vtable make_vtable() noexcept {
-            void (*move_destroy_fn)(void* src, void* dst) noexcept;
-            void (*destroy_fn)(void* target) noexcept;
+            void (*move_destroy_fn)(void* src, void* dst) noexcept = nullptr;
+            void (*destroy_fn)(void* target) noexcept = nullptr;
 
             if constexpr (std::is_trivially_copy_constructible_v<callable_type> && std::is_trivially_destructible_v<callable_type>) {
                 move_destroy_fn = nullptr;


### PR DESCRIPTION
Hi! I've found out that this great library couldn't be built on Clang 11.0.3-apple-darwin20.5.0 (Mac OSX SDK 10.15.4).
Actually this statement is described in standard.

```
The definition of a constexpr function shall satisfy the following requirements: [...] its function-body shall be
 = delete, = default, or a compound-statement that does not contain [...]
 a definition of a variable of non-literal type or of static or thread storage duration
 or for which no initialization is performed.
```
Now it's build good.