### PR TITLE
Replace printf with cout/cerr in tests

### DIFF
--- a/test/source/infra/assertions.cpp
+++ b/test/source/infra/assertions.cpp
@@ -1,6 +1,8 @@
 #include "infra/assertions.h"
 
-#include <cstdio>
+#include <iostream>
+#include <string>
+#include <string_view>
 
 namespace concurrencpp::tests::details {
     std::string to_string(bool value) {
@@ -56,74 +58,32 @@ namespace concurrencpp::tests::details {
     }
 
     void assert_equal_failed_impl(const std::string& a, const std::string& b) {
-        std::string error_msg = "assertion failed. ";
-        error_msg += "expected [";
-        error_msg += a;
-        error_msg += "] == [";
-        error_msg += b;
-        error_msg += "]";
-
-        fprintf(stderr, "%s", error_msg.data());
+        std::cerr << "assertion failed. expected [" << a << "] == [" << b << "]" << std::endl;
         std::abort();
     }
 
     void assert_not_equal_failed_impl(const std::string& a, const std::string& b) {
-        std::string error_msg = "assertion failed. ";
-        error_msg += "expected: [";
-        error_msg += a;
-        error_msg += "] =/= [";
-        error_msg += b;
-        error_msg += "]";
-
-        fprintf(stderr, "%s", error_msg.data());
+        std::cerr << "assertion failed. expected [" << a << "] =/= [" << b << "]" << std::endl;
         std::abort();
     }
 
     void assert_bigger_failed_impl(const std::string& a, const std::string& b) {
-        std::string error_msg = "assertion failed. ";
-        error_msg += "expected [";
-        error_msg += a;
-        error_msg += "] > [";
-        error_msg += b;
-        error_msg += "]";
-
-        fprintf(stderr, "%s", error_msg.data());
+        std::cerr << "assertion failed. expected [" << a << "] > [" << b << "]" << std::endl;
         std::abort();
     }
 
     void assert_smaller_failed_impl(const std::string& a, const std::string& b) {
-        std::string error_msg = "assertion failed. ";
-        error_msg += "expected [";
-        error_msg += a;
-        error_msg += "] < [";
-        error_msg += b;
-        error_msg += "]";
-
-        fprintf(stderr, "%s", error_msg.data());
+        std::cerr << "assertion failed. expected [" << a << "] < [" << b << "]" << std::endl;
         std::abort();
     }
 
     void assert_bigger_equal_failed_impl(const std::string& a, const std::string& b) {
-        std::string error_msg = "assertion failed. ";
-        error_msg += "expected [";
-        error_msg += a;
-        error_msg += "] >= [";
-        error_msg += b;
-        error_msg += "]";
-
-        fprintf(stderr, "%s", error_msg.data());
+        std::cerr << "assertion failed. expected [" << a << "] >= [" << b << "]" << std::endl;
         std::abort();
     }
 
     void assert_smaller_equal_failed_impl(const std::string& a, const std::string& b) {
-        std::string error_msg = "assertion failed. ";
-        error_msg += "expected [";
-        error_msg += a;
-        error_msg += "] <= [";
-        error_msg += b;
-        error_msg += "]";
-
-        fprintf(stderr, "%s", error_msg.data());
+        std::cerr << "assertion failed. expected [" << a << "] <= [" << b << "]" << std::endl;
         std::abort();
     }
 
@@ -132,14 +92,14 @@ namespace concurrencpp::tests::details {
 namespace concurrencpp::tests {
     void assert_true(bool condition) {
         if (!condition) {
-            fprintf(stderr, "%s", "assertion faild. expected: [true] actual: [false].");
+            std::cerr << "assertion failed. expected: [true] actual: [false].";
             std::abort();
         }
     }
 
     void assert_false(bool condition) {
         if (condition) {
-            fprintf(stderr, "%s", "assertion faild. expected: [false] actual: [true].");
+            std::cerr << "assertion failed. expected: [false] actual: [true].";
             std::abort();
         }
     }

--- a/test/source/infra/tester.cpp
+++ b/test/source/infra/tester.cpp
@@ -1,8 +1,7 @@
 #include "infra/tester.h"
 
 #include <chrono>
-
-#include <cstdio>
+#include <iostream>
 
 using concurrencpp::tests::test_step;
 using concurrencpp::tests::tester;
@@ -12,12 +11,12 @@ test_step::test_step(const char* step_name, std::function<void()> callable) : m_
 
 void test_step::launch_test_step() noexcept {
     const auto test_start_time = system_clock::now();
-    printf("\tTest-step started: %s\n", m_step_name);
+    std::cout << "\tTest-step started: " << m_step_name << std::endl;
 
     m_step();
 
     const auto elapsed_time = duration_cast<milliseconds>(system_clock::now() - test_start_time).count();
-    printf("\tTest-step ended (%lldms).\n", elapsed_time);
+    std::cout << "\tTest-step ended (" << elapsed_time << "ms)." << std::endl;
 }
 
 tester::tester(const char* test_name) noexcept : m_test_name(test_name) {}
@@ -27,15 +26,15 @@ void tester::add_step(const char* step_name, std::function<void()> callable) {
 }
 
 void tester::launch_test() noexcept {
-    printf("Test started: %s\n", m_test_name);
+    std::cout << "Test started: " << m_test_name << std::endl;
 
     for (auto& test_step : m_steps) {
         try {
             test_step.launch_test_step();
         } catch (const std::exception& ex) {
-            ::fprintf(stderr, "\tTest step terminated with an exception : %s\n", ex.what());
+            std::cerr << "\tTest step terminated with an exception : " << ex.what() << std::endl;
         }
     }
 
-    printf("Test ended.\n____________________\n");
+    std::cout << "Test ended.\n____________________" << std::endl;
 }


### PR DESCRIPTION
This replaces all uses of `printf` with `std::cout`/`std::cerr`. Fixes some compiler warnings on GCC about mismatches of format strings and argument types.