### PR TITLE
Mention vcpkg in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,3 +1724,11 @@ $ cmake --build build/test
 $ cd build/test
 $ ctest .
 ```
+
+##### Via vcpkg on Windows and *nix platforms
+
+Alternatively to building and installing the library manually, you may get stable releases of concurrencpp as [vcpkg](https://vcpkg.io/) packages:
+
+```shell
+$ vcpkg install concurrencpp
+```


### PR DESCRIPTION
concurrencpp is now available as a package in vcpkg: https://github.com/microsoft/vcpkg/tree/master/ports/concurrencpp. This MR adds a corresponding note to the README.