### PR TITLE
fix compilation issue with appleclang

### DIFF
--- a/include/concurrencpp/threads/cache_line.h
+++ b/include/concurrencpp/threads/cache_line.h
@@ -5,7 +5,7 @@
 
 #include <new>
 
-#ifdef __cpp_lib_hardware_interference_size && !defined(CRCPP_MAC_OS)
+#if  !defined(CRCPP_MAC_OS) && defined(__cpp_lib_hardware_interference_size) 
 #    define CRCPP_CACHE_LINE_ALIGNMENT std::hardware_destructive_interference_size
 #else
 #    define CRCPP_CACHE_LINE_ALIGNMENT 64

--- a/include/concurrencpp/threads/cache_line.h
+++ b/include/concurrencpp/threads/cache_line.h
@@ -1,9 +1,11 @@
 #ifndef CONCURRENCPP_CACHE_LINE_H
 #define CONCURRENCPP_CACHE_LINE_H
 
+#include "concurrencpp/platform_defs.h"
+
 #include <new>
 
-#ifdef __cpp_lib_hardware_interference_size
+#ifdef __cpp_lib_hardware_interference_size && !defined(CRCPP_MAC_OS)
 #    define CRCPP_CACHE_LINE_ALIGNMENT std::hardware_destructive_interference_size
 #else
 #    define CRCPP_CACHE_LINE_ALIGNMENT 64


### PR DESCRIPTION
apparently, applclang defines  `__cpp_lib_hardware_interference_size` but doesn't implement `std::hardware_destructive_interference_size`.
