### PR TITLE
Fix lambda in tests

### DIFF
--- a/test/source/tests/executor_tests/inline_executor_tests.cpp
+++ b/test/source/tests/executor_tests/inline_executor_tests.cpp
@@ -262,7 +262,7 @@ void concurrencpp::tests::test_inline_executor_bulk_submit_exception() {
     executor_shutdowner shutdown(executor);
     constexpr intptr_t id = 12345;
 
-    auto thrower = [id] {
+    auto thrower = [] {
         throw custom_exception(id);
     };
 

--- a/test/source/tests/executor_tests/manual_executor_tests.cpp
+++ b/test/source/tests/executor_tests/manual_executor_tests.cpp
@@ -451,7 +451,7 @@ void concurrencpp::tests::test_manual_executor_bulk_submit_exception() {
     executor_shutdowner shutdown(executor);
     constexpr intptr_t id = 12345;
 
-    auto thrower = [id] {
+    auto thrower = [] {
         throw custom_exception(id);
     };
 

--- a/test/source/tests/executor_tests/thread_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_executor_tests.cpp
@@ -299,7 +299,7 @@ void concurrencpp::tests::test_thread_executor_bulk_submit_exception() {
     executor_shutdowner shutdown(executor);
     constexpr intptr_t id = 12345;
 
-    auto thrower = [id] {
+    auto thrower = [] {
         throw custom_exception(id);
     };
 

--- a/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
@@ -306,7 +306,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_submit_exception() {
     executor_shutdowner shutdown(executor);
     constexpr intptr_t id = 12345;
 
-    auto thrower = [id] {
+    auto thrower = [] {
         throw custom_exception(id);
     };
 

--- a/test/source/tests/executor_tests/worker_thread_executor_tests.cpp
+++ b/test/source/tests/executor_tests/worker_thread_executor_tests.cpp
@@ -292,7 +292,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_submit_exception() {
     executor_shutdowner shutdown(executor);
     constexpr intptr_t id = 12345;
 
-    auto thrower = [id] {
+    auto thrower = [] {
         throw custom_exception(id);
     };
 


### PR DESCRIPTION
This fixes an issue I encountered when building the tests with a pre-release version of GCC 12:
> /home/user/concurrencpp/test/source/tests/executor_tests/inline_executor_tests.cpp:265:23: note: a lambda closure type has a deleted copy assignment operator

I get the same error with Clang on godbolt.org, only MSVC seems to accept it.

The suggested fix is to remove the captured variable as it is not needed since it is constexpr. It fixes the issue for both GCC and Clang.