### PR TITLE
Workaround conversion issue of span/vector in Clang 14, add Clang 14 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
     strategy:
       matrix:
         conf:
+          - name: Ubuntu (Clang 14 - TSAN)
+            os: ubuntu-22.04
+            cc: clang-14
+            cxx: clang++-14
+            tsan: YES
+
+          - name: Ubuntu (Clang 14 - no TSAN)
+            os: ubuntu-22.04
+            cc: clang-14
+            cxx: clang++-14
+            tsan: NO
+
           - name: Ubuntu (Clang 12 - TSAN)
             os: ubuntu-20.04
             cc: clang-12
@@ -79,12 +91,19 @@ jobs:
           "${{ steps.tools.outputs.ninja }}"
           ${{ steps.cores.outputs.plus_one }}]==])
 
+      - name: Install clang 14
+        working-directory: ${{ env.HOME }}
+        run: |
+            sudo apt-get update
+            sudo apt-get install clang-14 libc++-14-dev libc++abi-14-dev
+        if: ${{ startsWith(matrix.conf.os, 'ubuntu-22.04') }}
+
       - name: Install clang 12
         working-directory: ${{ env.HOME }}
         run: |
             sudo apt-get update
             sudo apt-get install clang-12 libc++-12-dev libc++abi-12-dev
-        if: ${{ startsWith(matrix.conf.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.conf.os, 'ubuntu-20.04') }}
 
       - name: Build examples
         run: cmake -P cmake/ciBuild.cmake -- example build/example

--- a/example/6_manual_executor/source/main.cpp
+++ b/example/6_manual_executor/source/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, const char* argv[]) {
         std::this_thread::sleep_for(std::chrono::seconds(5));
 
         std::cout << "thread_id " << std::this_thread::get_id() << " is posting " << tasks.size() << " tasks." << std::endl;
-        manual_executor->bulk_post<dummy_task>(tasks);
+        manual_executor->bulk_post(tasks);
     });
 
     threads.emplace_back([manual_executor] {
@@ -53,7 +53,7 @@ int main(int argc, const char* argv[]) {
         std::this_thread::sleep_for(std::chrono::seconds(12));
 
         std::cout << "thread_id " << std::this_thread::get_id() << " is posting " << tasks.size() << " tasks." << std::endl;
-        manual_executor->bulk_post<dummy_task>(tasks);
+        manual_executor->bulk_post(tasks);
     });
 
     threads.emplace_back([manual_executor] {
@@ -62,7 +62,7 @@ int main(int argc, const char* argv[]) {
         std::this_thread::sleep_for(std::chrono::seconds(18));
 
         std::cout << "thread_id " << std::this_thread::get_id() << " is posting " << tasks.size() << " tasks." << std::endl;
-        manual_executor->bulk_post<dummy_task>(tasks);
+        manual_executor->bulk_post(tasks);
     });
 
     std::this_thread::sleep_for(std::chrono::seconds(35));

--- a/include/concurrencpp/executors/derivable_executor.h
+++ b/include/concurrencpp/executors/derivable_executor.h
@@ -26,23 +26,15 @@ namespace concurrencpp {
             return do_submit(self(), std::forward<callable_type>(callable), std::forward<argument_types>(arguments)...);
         }
 
-        template<class callable_type>
-        void bulk_post(std::span<callable_type> callable_list) {
-            return do_bulk_post(self(), callable_list);
-        }
-
-        template<class callable_type>
-        void bulk_post(std::vector<callable_type> &callable_list) {
+        template<class callable_list_type>
+        void bulk_post(callable_list_type &&callable_list) {
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_post(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
-        template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
-        std::vector<concurrencpp::result<return_type>> bulk_submit(std::span<callable_type> callable_list) {
-            return do_bulk_submit(self(), callable_list);
-        }
-
-        template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
-        std::vector<concurrencpp::result<return_type>> bulk_submit(std::vector<callable_type> &callable_list) {
+        template<class callable_list_type>
+        auto bulk_submit(callable_list_type &&callable_list) {
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_submit(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };

--- a/include/concurrencpp/executors/derivable_executor.h
+++ b/include/concurrencpp/executors/derivable_executor.h
@@ -31,9 +31,19 @@ namespace concurrencpp {
             return do_bulk_post(self(), callable_list);
         }
 
+        template<class callable_type>
+        void bulk_post(std::vector<callable_type> &callable_list) {
+            return do_bulk_post(self(), std::span<callable_type>(callable_list.begin(), callable_list.end()));
+        }
+
         template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
         std::vector<concurrencpp::result<return_type>> bulk_submit(std::span<callable_type> callable_list) {
             return do_bulk_submit(self(), callable_list);
+        }
+
+        template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
+        std::vector<concurrencpp::result<return_type>> bulk_submit(std::vector<callable_type> &callable_list) {
+            return do_bulk_submit(self(), std::span<callable_type>(callable_list.begin(), callable_list.end()));
         }
     };
 }  // namespace concurrencpp

--- a/include/concurrencpp/executors/derivable_executor.h
+++ b/include/concurrencpp/executors/derivable_executor.h
@@ -4,6 +4,8 @@
 #include "concurrencpp/utils/bind.h"
 #include "concurrencpp/executors/executor.h"
 
+#include <iterator>
+
 namespace concurrencpp {
     template<class concrete_executor_type>
     class derivable_executor : public executor {
@@ -28,13 +30,13 @@ namespace concurrencpp {
 
         template<class callable_list_type>
         void bulk_post(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
+            using callable_type = std::iter_value_t<callable_list_type>;
             return do_bulk_post(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
         template<class callable_list_type>
         auto bulk_submit(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
+            using callable_type = std::iter_value_t<callable_list_type>;
             return do_bulk_submit(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };

--- a/include/concurrencpp/executors/derivable_executor.h
+++ b/include/concurrencpp/executors/derivable_executor.h
@@ -28,14 +28,14 @@ namespace concurrencpp {
 
         template<class callable_list_type>
         void bulk_post(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
-            return do_bulk_post(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
+            using callable_type = std::remove_reference_t<decltype(*std::data(callable_list))>;
+            return do_bulk_post(self(), std::span<callable_type>(std::data(callable_list), std::size(callable_list)));
         }
 
         template<class callable_list_type>
         auto bulk_submit(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
-            return do_bulk_submit(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
+            using callable_type = std::remove_reference_t<decltype(*std::data(callable_list))>;
+            return do_bulk_submit(self(), std::span<callable_type>(std::data(callable_list), std::size(callable_list)));
         }
     };
 }  // namespace concurrencpp

--- a/include/concurrencpp/executors/derivable_executor.h
+++ b/include/concurrencpp/executors/derivable_executor.h
@@ -4,8 +4,6 @@
 #include "concurrencpp/utils/bind.h"
 #include "concurrencpp/executors/executor.h"
 
-#include <iterator>
-
 namespace concurrencpp {
     template<class concrete_executor_type>
     class derivable_executor : public executor {
@@ -30,13 +28,13 @@ namespace concurrencpp {
 
         template<class callable_list_type>
         void bulk_post(callable_list_type &&callable_list) {
-            using callable_type = std::iter_value_t<callable_list_type>;
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_post(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
         template<class callable_list_type>
         auto bulk_submit(callable_list_type &&callable_list) {
-            using callable_type = std::iter_value_t<callable_list_type>;
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_submit(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };

--- a/include/concurrencpp/executors/derivable_executor.h
+++ b/include/concurrencpp/executors/derivable_executor.h
@@ -33,7 +33,7 @@ namespace concurrencpp {
 
         template<class callable_type>
         void bulk_post(std::vector<callable_type> &callable_list) {
-            return do_bulk_post(self(), std::span<callable_type>(callable_list.begin(), callable_list.end()));
+            return do_bulk_post(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
         template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
@@ -43,7 +43,7 @@ namespace concurrencpp {
 
         template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
         std::vector<concurrencpp::result<return_type>> bulk_submit(std::vector<callable_type> &callable_list) {
-            return do_bulk_submit(self(), std::span<callable_type>(callable_list.begin(), callable_list.end()));
+            return do_bulk_submit(self(), std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };
 }  // namespace concurrencpp

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -63,7 +63,7 @@ namespace concurrencpp {
                 tasks.emplace_back(details::bind_with_try_catch(std::move(callable)));
             }
 
-            std::span<task> span = tasks;
+            std::span<task> span(tasks.begin(), tasks.end());
             executor_ref.enqueue(span);
         }
 
@@ -81,7 +81,7 @@ namespace concurrencpp {
             }
 
             assert(!accumulator.empty());
-            std::span<task> span = accumulator;
+            std::span<task> span(accumulator.begin(), accumulator.end());
             executor_ref.enqueue(span);
             return results;
         }

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -4,6 +4,7 @@
 #include "concurrencpp/task.h"
 #include "concurrencpp/results/result.h"
 
+#include <iterator>
 #include <span>
 #include <vector>
 #include <string>
@@ -113,13 +114,13 @@ namespace concurrencpp {
 
         template<class callable_list_type>
         void bulk_post(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
+            using callable_type = std::iter_value_t<callable_list_type>;
             return do_bulk_post(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
         template<class callable_list_type>
         auto bulk_submit(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
+            using callable_type = std::iter_value_t<callable_list_type>;
             return do_bulk_submit(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -63,7 +63,7 @@ namespace concurrencpp {
                 tasks.emplace_back(details::bind_with_try_catch(std::move(callable)));
             }
 
-            std::span<task> span(tasks.begin(), tasks.end());
+            std::span<task> span(tasks.data(), tasks.size());
             executor_ref.enqueue(span);
         }
 
@@ -81,7 +81,7 @@ namespace concurrencpp {
             }
 
             assert(!accumulator.empty());
-            std::span<task> span(accumulator.begin(), accumulator.end());
+            std::span<task> span(accumulator.data(), accumulator.size());
             executor_ref.enqueue(span);
             return results;
         }

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -4,7 +4,6 @@
 #include "concurrencpp/task.h"
 #include "concurrencpp/results/result.h"
 
-#include <iterator>
 #include <span>
 #include <vector>
 #include <string>
@@ -114,13 +113,13 @@ namespace concurrencpp {
 
         template<class callable_list_type>
         void bulk_post(callable_list_type &&callable_list) {
-            using callable_type = std::iter_value_t<callable_list_type>;
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_post(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
         template<class callable_list_type>
         auto bulk_submit(callable_list_type &&callable_list) {
-            using callable_type = std::iter_value_t<callable_list_type>;
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_submit(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -111,23 +111,15 @@ namespace concurrencpp {
             return do_submit(*this, std::forward<callable_type>(callable), std::forward<argument_types>(arguments)...);
         }
 
-        template<class callable_type>
-        void bulk_post(std::span<callable_type> callable_list) {
-            return do_bulk_post(*this, callable_list);
-        }
-
-        template<class callable_type>
-        void bulk_post(std::vector<callable_type> &callable_list) {
+        template<class callable_list_type>
+        void bulk_post(callable_list_type &&callable_list) {
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_post(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
 
-        template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
-        std::vector<concurrencpp::result<return_type>> bulk_submit(std::span<callable_type> callable_list) {
-            return do_bulk_submit(*this, callable_list);
-        }
-
-        template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
-        std::vector<concurrencpp::result<return_type>> bulk_submit(std::vector<callable_type> &callable_list) {
+        template<class callable_list_type>
+        auto bulk_submit(callable_list_type &&callable_list) {
+            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
             return do_bulk_submit(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -116,9 +116,19 @@ namespace concurrencpp {
             return do_bulk_post(*this, callable_list);
         }
 
+        template<class callable_type>
+        void bulk_post(std::vector<callable_type> &callable_list) {
+            return do_bulk_post(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
+        }
+
         template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
         std::vector<concurrencpp::result<return_type>> bulk_submit(std::span<callable_type> callable_list) {
             return do_bulk_submit(*this, callable_list);
+        }
+
+        template<class callable_type, class return_type = std::invoke_result_t<callable_type>>
+        std::vector<concurrencpp::result<return_type>> bulk_submit(std::vector<callable_type> &callable_list) {
+            return do_bulk_submit(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
         }
     };
 }  // namespace concurrencpp

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -113,14 +113,14 @@ namespace concurrencpp {
 
         template<class callable_list_type>
         void bulk_post(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
-            return do_bulk_post(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
+            using callable_type = std::remove_reference_t<decltype(*std::data(callable_list))>;
+            return do_bulk_post(*this, std::span<callable_type>(std::data(callable_list), std::size(callable_list)));
         }
 
         template<class callable_list_type>
         auto bulk_submit(callable_list_type &&callable_list) {
-            using callable_type = std::remove_reference_t<decltype(*callable_list.data())>;
-            return do_bulk_submit(*this, std::span<callable_type>(callable_list.data(), callable_list.size()));
+            using callable_type = std::remove_reference_t<decltype(*std::data(callable_list))>;
+            return do_bulk_submit(*this, std::span<callable_type>(std::data(callable_list), std::size(callable_list)));
         }
     };
 }  // namespace concurrencpp

--- a/test/source/tests/executor_tests/inline_executor_tests.cpp
+++ b/test/source/tests/executor_tests/inline_executor_tests.cpp
@@ -221,7 +221,7 @@ void concurrencpp::tests::test_inline_executor_bulk_post_foreign() {
         stubs.emplace_back(observer.get_testing_stub());
     }
 
-    std::span<testing_stub> span = stubs;
+    std::span<testing_stub> span(stubs.data(), stubs.size());
     executor->bulk_post<testing_stub>(span);
 
     assert_equal(observer.get_execution_count(), task_count);

--- a/test/source/tests/executor_tests/inline_executor_tests.cpp
+++ b/test/source/tests/executor_tests/inline_executor_tests.cpp
@@ -205,7 +205,7 @@ void concurrencpp::tests::test_inline_executor_bulk_post_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4);
 
-    executor->bulk_post<decltype(thrower)>(tasks);
+    executor->bulk_post(tasks);
 }
 
 void concurrencpp::tests::test_inline_executor_bulk_post_foreign() {
@@ -222,7 +222,7 @@ void concurrencpp::tests::test_inline_executor_bulk_post_foreign() {
     }
 
     std::span<testing_stub> span(stubs.data(), stubs.size());
-    executor->bulk_post<testing_stub>(span);
+    executor->bulk_post(span);
 
     assert_equal(observer.get_execution_count(), task_count);
     assert_equal(observer.get_destruction_count(), task_count);
@@ -243,7 +243,7 @@ void concurrencpp::tests::test_inline_executor_bulk_post_inline() {
             stubs.emplace_back(observer.get_testing_stub());
         }
 
-        executor->bulk_post<testing_stub>(stubs);
+        executor->bulk_post(stubs);
     });
 
     assert_equal(observer.get_execution_count(), task_count);
@@ -269,7 +269,7 @@ void concurrencpp::tests::test_inline_executor_bulk_submit_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4, thrower);
 
-    auto results = executor->bulk_submit<decltype(thrower)>(tasks);
+    auto results = executor->bulk_submit(tasks);
 
     for (auto& result : results) {
         result.wait();
@@ -290,7 +290,7 @@ void concurrencpp::tests::test_inline_executor_bulk_submit_foreign() {
         stubs.emplace_back(observer.get_testing_stub(i));
     }
 
-    auto results = executor->bulk_submit<value_testing_stub>(stubs);
+    auto results = executor->bulk_submit(stubs);
     for (size_t i = 0; i < task_count; i++) {
         assert_equal(results[i].status(), result_status::value);
         assert_equal(results[i].get(), i);
@@ -315,7 +315,7 @@ void concurrencpp::tests::test_inline_executor_bulk_submit_inline() {
             stubs.emplace_back(observer.get_testing_stub(i));
         }
 
-        return executor->bulk_submit<value_testing_stub>(stubs);
+        return executor->bulk_submit(stubs);
     });
 
     auto results = results_res.get();

--- a/test/source/tests/executor_tests/manual_executor_tests.cpp
+++ b/test/source/tests/executor_tests/manual_executor_tests.cpp
@@ -364,7 +364,7 @@ void concurrencpp::tests::test_manual_executor_bulk_post_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4);
 
-    executor->bulk_post<decltype(thrower)>(tasks);
+    executor->bulk_post(tasks);
     assert_equal(executor->loop(4), 4);
 }
 
@@ -380,7 +380,7 @@ void concurrencpp::tests::test_manual_executor_bulk_post_foreign() {
         stubs.emplace_back(observer.get_testing_stub());
     }
 
-    executor->bulk_post<testing_stub>(stubs);
+    executor->bulk_post(stubs);
 
     assert_equal(executor->size(), task_count);
     assert_false(executor->empty());
@@ -414,7 +414,7 @@ void concurrencpp::tests::test_manual_executor_bulk_post_inline() {
             stubs.emplace_back(observer.get_testing_stub());
         }
 
-        executor->bulk_post<testing_stub>(stubs);
+        executor->bulk_post(stubs);
     });
 
     // the tasks are not enqueued yet, only the spawning task is.
@@ -458,7 +458,7 @@ void concurrencpp::tests::test_manual_executor_bulk_submit_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4, thrower);
 
-    auto results = executor->bulk_submit<decltype(thrower)>(tasks);
+    auto results = executor->bulk_submit(tasks);
     assert_equal(executor->loop(4), 4);
 
     for (auto& result : results) {
@@ -480,7 +480,7 @@ void concurrencpp::tests::test_manual_executor_bulk_submit_foreign() {
         stubs.emplace_back(observer.get_testing_stub(i));
     }
 
-    auto results = executor->bulk_submit<value_testing_stub>(stubs);
+    auto results = executor->bulk_submit(stubs);
 
     assert_false(executor->empty());
     assert_equal(executor->size(), task_count);
@@ -522,7 +522,7 @@ void concurrencpp::tests::test_manual_executor_bulk_submit_inline() {
             stubs.emplace_back(observer.get_testing_stub(i));
         }
 
-        return executor->bulk_submit<value_testing_stub>(stubs);
+        return executor->bulk_submit(stubs);
     });
 
     // the tasks are not enqueued yet, only the spawning task is.

--- a/test/source/tests/executor_tests/thread_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_executor_tests.cpp
@@ -241,7 +241,7 @@ void concurrencpp::tests::test_thread_executor_bulk_post_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4);
 
-    executor->bulk_post<decltype(thrower)>(tasks);
+    executor->bulk_post(tasks);
 }
 
 void concurrencpp::tests::test_thread_executor_bulk_post_foreign() {
@@ -257,7 +257,7 @@ void concurrencpp::tests::test_thread_executor_bulk_post_foreign() {
         stubs.emplace_back(observer.get_testing_stub());
     }
 
-    executor->bulk_post<testing_stub>(stubs);
+    executor->bulk_post(stubs);
 
     assert_true(observer.wait_execution_count(task_count, std::chrono::minutes(1)));
     assert_true(observer.wait_destruction_count(task_count, std::chrono::minutes(1)));
@@ -279,7 +279,7 @@ void concurrencpp::tests::test_thread_executor_bulk_post_inline() {
             stubs.emplace_back(observer.get_testing_stub());
         }
 
-        executor->bulk_post<testing_stub>(stubs);
+        executor->bulk_post(stubs);
     });
 
     assert_true(observer.wait_execution_count(task_count, std::chrono::minutes(1)));
@@ -306,7 +306,7 @@ void concurrencpp::tests::test_thread_executor_bulk_submit_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4, thrower);
 
-    auto results = executor->bulk_submit<decltype(thrower)>(tasks);
+    auto results = executor->bulk_submit(tasks);
 
     for (auto& result : results) {
         result.wait();
@@ -327,7 +327,7 @@ void concurrencpp::tests::test_thread_executor_bulk_submit_foreign() {
         stubs.emplace_back(observer.get_testing_stub(i));
     }
 
-    auto results = executor->bulk_submit<value_testing_stub>(stubs);
+    auto results = executor->bulk_submit(stubs);
 
     for (size_t i = 0; i < task_count; i++) {
         assert_equal(results[i].get(), i);
@@ -353,7 +353,7 @@ void concurrencpp::tests::test_thread_executor_bulk_submit_inline() {
             stubs.emplace_back(observer.get_testing_stub(i));
         }
 
-        return executor->bulk_submit<value_testing_stub>(stubs);
+        return executor->bulk_submit(stubs);
     });
 
     auto results = results_res.get();

--- a/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
@@ -247,7 +247,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_post_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4);
 
-    executor->bulk_post<decltype(thrower)>(tasks);
+    executor->bulk_post(tasks);
     std::this_thread::sleep_for(std::chrono::seconds(2));
 }
 
@@ -266,7 +266,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_post_foreign() {
         stubs.emplace_back(observer.get_testing_stub());
     }
 
-    executor->bulk_post<testing_stub>(stubs);
+    executor->bulk_post(stubs);
 
     assert_true(observer.wait_execution_count(task_count, std::chrono::minutes(2)));
     assert_true(observer.wait_destruction_count(task_count, std::chrono::minutes(2)));
@@ -288,7 +288,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_post_inline() {
             stubs.emplace_back(observer.get_testing_stub());
         }
 
-        executor->bulk_post<testing_stub>(stubs);
+        executor->bulk_post(stubs);
     });
 
     assert_true(observer.wait_execution_count(task_count, std::chrono::minutes(2)));
@@ -313,7 +313,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_submit_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4, thrower);
 
-    auto results = executor->bulk_submit<decltype(thrower)>(tasks);
+    auto results = executor->bulk_submit(tasks);
 
     for (auto& result : results) {
         result.wait();
@@ -336,7 +336,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_submit_foreign() {
         stubs.emplace_back(observer.get_testing_stub(i));
     }
 
-    auto results = executor->bulk_submit<value_testing_stub>(stubs);
+    auto results = executor->bulk_submit(stubs);
 
     for (size_t i = 0; i < task_count; i++) {
         assert_equal(results[i].get(), i);
@@ -362,7 +362,7 @@ void concurrencpp::tests::test_thread_pool_executor_bulk_submit_inline() {
             stubs.emplace_back(observer.get_testing_stub(i));
         }
 
-        return executor->bulk_submit<value_testing_stub>(stubs);
+        return executor->bulk_submit(stubs);
     });
 
     auto results = results_res.get();

--- a/test/source/tests/executor_tests/worker_thread_executor_tests.cpp
+++ b/test/source/tests/executor_tests/worker_thread_executor_tests.cpp
@@ -234,7 +234,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_post_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4);
 
-    executor->bulk_post<decltype(thrower)>(tasks);
+    executor->bulk_post(tasks);
 
     std::this_thread::sleep_for(std::chrono::seconds(2));
 }
@@ -252,7 +252,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_post_foreign() {
         stubs.emplace_back(observer.get_testing_stub());
     }
 
-    executor->bulk_post<testing_stub>(stubs);
+    executor->bulk_post(stubs);
 
     assert_true(observer.wait_execution_count(task_count, std::chrono::minutes(1)));
     assert_true(observer.wait_destruction_count(task_count, std::chrono::minutes(1)));
@@ -273,7 +273,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_post_inline() {
             stubs.emplace_back(observer.get_testing_stub());
         }
 
-        executor->bulk_post<testing_stub>(stubs);
+        executor->bulk_post(stubs);
     });
 
     assert_true(observer.wait_execution_count(task_count, std::chrono::minutes(1)));
@@ -299,7 +299,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_submit_exception() {
     std::vector<decltype(thrower)> tasks;
     tasks.resize(4, thrower);
 
-    auto results = executor->bulk_submit<decltype(thrower)>(tasks);
+    auto results = executor->bulk_submit(tasks);
 
     for (auto& result : results) {
         result.wait();
@@ -320,7 +320,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_submit_foreign() {
         stubs.emplace_back(observer.get_testing_stub(i));
     }
 
-    auto results = executor->bulk_submit<value_testing_stub>(stubs);
+    auto results = executor->bulk_submit(stubs);
     for (size_t i = 0; i < task_count; i++) {
         assert_equal(results[i].get(), i);
     }
@@ -344,7 +344,7 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_submit_inline() {
             stubs.emplace_back(observer.get_testing_stub(i));
         }
 
-        return executor->bulk_submit<value_testing_stub>(stubs);
+        return executor->bulk_submit(stubs);
     });
 
     auto results = results_res.get();

--- a/test/source/thread_sanitizer/executors.cpp
+++ b/test/source/thread_sanitizer/executors.cpp
@@ -226,7 +226,7 @@ void test_executor_bulk_post(std::shared_ptr<concurrencpp::executor> executor, s
 
             std::this_thread::sleep_until(post_tp);
 
-            executor->bulk_post<decltype(task)>(tasks);
+            executor->bulk_post(tasks);
         });
     }
 
@@ -276,7 +276,7 @@ void test_executor_bulk_submit(std::shared_ptr<concurrencpp::executor> executor,
 
             std::this_thread::sleep_until(submit_tp);
 
-            auto results = executor->bulk_submit<val_returner>(tasks);
+            auto results = executor->bulk_submit(tasks);
 
             for (size_t i = 0; i < tasks_per_thread; i++) {
                 const auto val = results[i].get();


### PR DESCRIPTION
This suggests a workaround for #73 which allows the library and tests to compile using Clang 14. Instead of adding the two overloads to `bulk_post` and `bulk_submit`, an alternative workaround could be to change various places in the tests where vectors are passed to these functions. But it would have required many more changes so I went with this other approach.

Also adds Clang 14 on Ubuntu 22.04 to CI.