### PR TITLE
Make pthreads a public dependency, fix Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
             cxx: clang++
             tsan: NO
 
-          - name: Windows (Visual Studio Enterprise 2019)
-            os: windows-latest
+          - name: Windows (Visual Studio Enterprise 2022)
+            os: windows-2022
             cc: cl
             cxx: cl
             tsan: NO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ target_compile_features(concurrencpp PUBLIC cxx_std_20)
 
 target_coroutine_options(concurrencpp)
 
+find_package(Threads REQUIRED)
+target_link_libraries(concurrencpp PUBLIC Threads::Threads)
+
 find_library(LIBRT NAMES rt DOC "Path to the Real Time shared library")
 target_link_libraries(concurrencpp PUBLIC "$<$<BOOL:${LIBRT}>:${LIBRT}>")
 

--- a/cmake/concurrencppConfig.cmake
+++ b/cmake/concurrencppConfig.cmake
@@ -1,1 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/concurrencppTargets.cmake")

--- a/cmake/coroutineOptions.cmake
+++ b/cmake/coroutineOptions.cmake
@@ -7,9 +7,6 @@ function(target_coroutine_options TARGET)
     return()
   endif()
 
-  find_package(Threads REQUIRED)
-  target_link_libraries(${TARGET} PRIVATE Threads::Threads)
-
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(${TARGET} PUBLIC -stdlib=libc++ -fcoroutines-ts)
     target_link_options(${TARGET} PUBLIC -stdlib=libc++)

--- a/cmake/coroutineOptions.cmake
+++ b/cmake/coroutineOptions.cmake
@@ -4,10 +4,7 @@
 function(target_coroutine_options TARGET)
   if(MSVC)
     target_compile_options(${TARGET} PUBLIC /std:c++latest /permissive-)
-    return()
-  endif()
-
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(${TARGET} PUBLIC -stdlib=libc++ -fcoroutines-ts)
     target_link_options(${TARGET} PUBLIC -stdlib=libc++)
     set_target_properties(${TARGET} PROPERTIES CXX_EXTENSIONS NO)

--- a/cmake/setCiVars.cmake
+++ b/cmake/setCiVars.cmake
@@ -1,6 +1,6 @@
 if (os MATCHES "^windows")
   execute_process(
-    COMMAND "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat" && set
+    COMMAND "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat" && set
     OUTPUT_FILE environment_script_output.txt
   )
   file(STRINGS environment_script_output.txt output_lines)


### PR DESCRIPTION
Addresses #78 by making `Threads::Threads` a public CMake dependency and moving it out of `target_coroutine_options`.