### PR TITLE
Add Clang 15 to CI, catch exceptions by const-ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,25 @@ jobs:
     strategy:
       matrix:
         conf:
-          - name: Ubuntu (Clang 12 - TSAN)
+          - name: Ubuntu 22.04 (Clang 15 - TSAN)
+            os: ubuntu-22.04
+            cc: clang-15
+            cxx: clang++-15
+            tsan: YES
+
+          - name: Ubuntu 22.04 (Clang 15 - no TSAN)
+            os: ubuntu-22.04
+            cc: clang-15
+            cxx: clang++-15
+            tsan: NO
+
+          - name: Ubuntu 20.04 (Clang 12 - TSAN)
             os: ubuntu-20.04
             cc: clang-12
             cxx: clang++-12
             tsan: YES
 
-          - name: Ubuntu (Clang 12 - no TSAN)
+          - name: Ubuntu 20.04 (Clang 12 - no TSAN)
             os: ubuntu-20.04
             cc: clang-12
             cxx: clang++-12
@@ -79,12 +91,21 @@ jobs:
           "${{ steps.tools.outputs.ninja }}"
           ${{ steps.cores.outputs.plus_one }}]==])
 
+      - name: Install clang 15
+        working-directory: ${{ env.HOME }}
+        run: |
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+            sudo add-apt-repository -y "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+            sudo apt-get update
+            sudo apt-get install clang-15 libc++-15-dev libc++abi-15-dev
+        if: ${{ startsWith(matrix.conf.os, 'ubuntu-22.04') }}
+
       - name: Install clang 12
         working-directory: ${{ env.HOME }}
         run: |
             sudo apt-get update
             sudo apt-get install clang-12 libc++-12-dev libc++abi-12-dev
-        if: ${{ startsWith(matrix.conf.os, 'ubuntu') }}
+        if: ${{ startsWith(matrix.conf.os, 'ubuntu-20.04') }}
 
       - name: Build examples
         run: cmake -P cmake/ciBuild.cmake -- example build/example

--- a/test/include/utils/test_ready_lazy_result.h
+++ b/test/include/utils/test_ready_lazy_result.h
@@ -60,7 +60,7 @@ namespace concurrencpp::tests {
 
         try {
             co_await result;
-        } catch (custom_exception e) {
+        } catch (const custom_exception& e) {
             assert_equal(e.id, id);
             co_return;
         } catch (...) {

--- a/test/include/utils/test_ready_result.h
+++ b/test/include/utils/test_ready_result.h
@@ -124,7 +124,7 @@ namespace concurrencpp::tests {
 
         try {
             result.get();
-        } catch (custom_exception e) {
+        } catch (const custom_exception& e) {
             return assert_equal(e.id, id);
         } catch (...) {
         }
@@ -140,7 +140,7 @@ namespace concurrencpp::tests {
         for (size_t i = 0; i < 10; i++) {
             try {
                 result.get();
-            } catch (custom_exception e) {
+            } catch (const custom_exception& e) {
                 assert_equal(e.id, id);
                 if (i == 9) {
                     return;


### PR DESCRIPTION
This adds Clang 15 build jobs (with TSAN and without) to CI. It also fixes an issue reported by @ohanar in https://github.com/David-Haim/concurrencpp/issues/86#issue-1386837528 related to three locations where exceptions are catched by value. I noticed TSAN errors that are probably related and seem to be fixed by catching exceptions by const-ref.

<details>

```
test 8
      Start  8: result_tests

8: Test command: /home/runner/work/concurrencpp/concurrencpp/build/test/result_tests
8: Test timeout computed to be: 10000000
8: Test started: result test
8: 	Test-step started: constructor
8: 	Test-step ended (0ms).
8: 	Test-step started: status
8: 	Test-step ended (0ms).
8: 	Test-step started: get
8: ==================
8: WARNING: ThreadSanitizer: data race (pid=5730)
8:   Write of size 8 at 0x7b24000049a8 by thread T6:
8:     #0 free <null> (result_tests+0x4fc94) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #1 __cxa_decrement_exception_refcount <null> (libc++abi.so.1+0x275d9) (BuildId: 810aa8c62cedf1117c9adaf41b3ad40b4c35ef62)
8:     #2 decltype(std::declval<void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>()()) std::__1::__invoke[abi:v15002]<void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>(void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()&&) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (result_tests+0xf02bd) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #3 void std::__1::__thread_execute[abi:v15002]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/lib/llvm-15/bin/../include/c++/v1/thread:284:5 (result_tests+0xf02bd)
8:     #4 void* std::__1::__thread_proxy[abi:v15002]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>>(void*) /usr/lib/llvm-15/bin/../include/c++/v1/thread:295:5 (result_tests+0xf02bd)
8: 
8:   Previous read of size 8 at 0x7b24000049a8 by main thread:
8:     #0 concurrencpp::tests::custom_exception::custom_exception(concurrencpp::tests::custom_exception const&) /home/runner/work/concurrencpp/concurrencpp/test/include/utils/custom_exception.h:8:12 (result_tests+0xefc95) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #1 void concurrencpp::tests::test_ready_result_custom_exception<void>(concurrencpp::result<void>, long) /home/runner/work/concurrencpp/concurrencpp/test/include/utils/test_ready_result.h:127:35 (result_tests+0xefc95)
8:     #2 void concurrencpp::tests::test_result_get_impl<void>() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:190:9 (result_tests+0xd8977) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #3 concurrencpp::tests::test_result_get() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:[232](https://github.com/chausner/concurrencpp/actions/runs/3166664285/jobs/5156524168#step:11:233):5 (result_tests+0xd1e89) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #4 decltype(std::declval<void (*&)()>()()) std::__1::__invoke[abi:v15002]<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (result_tests+0x102469) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #5 void std::__1::__invoke_void_return_wrapper<void, true>::__call<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:479:9 (result_tests+0x102469)
8:     #6 std::__1::__function::__alloc_func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()[abi:v15002]() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:185:16 (result_tests+0x102469)
8:     #7 std::__1::__function::__func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:359:12 (result_tests+0x102469)
8:     #8 std::__1::__function::__value_func<void ()>::operator()[abi:v15002]() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:512:16 (result_tests+0x104562) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #9 std::__1::function<void ()>::operator()() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:1187:12 (result_tests+0x104562)
8:     #10 concurrencpp::tests::test_step::launch_test_step() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:16:5 (result_tests+0x104562)
8:     #11 concurrencpp::tests::tester::launch_test() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:33:23 (result_tests+0x10484c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #12 main /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:725:12 (result_tests+0xd246c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8: 
8:   Thread T6 (tid=5737, running) created by main thread at:
8:     #0 pthread_create <null> (result_tests+0x50e0d) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #1 std::__1::__libcpp_thread_create[abi:v15002](unsigned long*, void* (*)(void*), void*) /usr/lib/llvm-15/bin/../include/c++/v1/__threading_support:376:10 (result_tests+0xefa77) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #2 std::__1::thread::thread<void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'(), void>(void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()&&) /usr/lib/llvm-15/bin/../include/c++/v1/thread:311:16 (result_tests+0xefa77)
8:     #3 void concurrencpp::tests::test_result_get_impl<void>() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:179:21 (result_tests+0xd8890) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #4 concurrencpp::tests::test_result_get() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:232:5 (result_tests+0xd1e89) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #5 decltype(std::declval<void (*&)()>()()) std::__1::__invoke[abi:v15002]<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (result_tests+0x102469) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #6 void std::__1::__invoke_void_return_wrapper<void, true>::__call<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:479:9 (result_tests+0x102469)
8:     #7 std::__1::__function::__alloc_func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()[abi:v15002]() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:185:16 (result_tests+0x102469)
8:     #8 std::__1::__function::__func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:359:12 (result_tests+0x102469)
8:     #9 std::__1::__function::__value_func<void ()>::operator()[abi:v15002]() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:512:16 (result_tests+0x104562) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #10 std::__1::function<void ()>::operator()() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:1187:12 (result_tests+0x104562)
8:     #11 concurrencpp::tests::test_step::launch_test_step() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:16:5 (result_tests+0x104562)
8:     #12 concurrencpp::tests::tester::launch_test() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:33:23 (result_tests+0x10484c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8:     #13 main /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:725:12 (result_tests+0xd246c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
8: 
8: SUMMARY: ThreadSanitizer: data race (/home/runner/work/concurrencpp/concurrencpp/build/test/result_tests+0x4fc94) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635) in free
8: ==================
8: 	Test-step ended (1590ms).
8: 	Test-step started: wait
8: 	Test-step ended (1755ms).
8: 	Test-step started: wait_for
8: 	Test-step ended (2511ms).
8: 	Test-step started: wait_until
8: 	Test-step ended (2533ms).
8: 	Test-step started: operator =
8: 	Test-step ended (0ms).
8: Test ended.
8: ____________________
8: ThreadSanitizer: reported 1 warnings
 8/36 Test  #8: result_tests .....................***Failed    8.41 sec
Test started: result test
	Test-step started: constructor
	Test-step ended (0ms).
	Test-step started: status
	Test-step ended (0ms).
	Test-step started: get
==================
WARNING: ThreadSanitizer: data race (pid=5730)
  Write of size 8 at 0x7b[240](https://github.com/chausner/concurrencpp/actions/runs/3166664285/jobs/5156524168#step:11:241)00049a8 by thread T6:
    #0 free <null> (result_tests+0x4fc94) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #1 __cxa_decrement_exception_refcount <null> (libc++abi.so.1+0x275d9) (BuildId: 810aa8c62cedf1117c9adaf41b3ad40b4c35ef62)
    #2 decltype(std::declval<void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>()()) std::__1::__invoke[abi:v15002]<void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>(void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()&&) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (result_tests+0xf02bd) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #3 void std::__1::__thread_execute[abi:v15002]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>&, std::__1::__tuple_indices<>) /usr/lib/llvm-15/bin/../include/c++/v1/thread:284:5 (result_tests+0xf02bd)
    #4 void* std::__1::__thread_proxy[abi:v15002]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()>>(void*) /usr/lib/llvm-15/bin/../include/c++/v1/thread:295:5 (result_tests+0xf02bd)

  Previous read of size 8 at 0x7b24000049a8 by main thread:
    #0 concurrencpp::tests::custom_exception::custom_exception(concurrencpp::tests::custom_exception const&) /home/runner/work/concurrencpp/concurrencpp/test/include/utils/custom_exception.h:8:12 (result_tests+0xefc95) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #1 void concurrencpp::tests::test_ready_result_custom_exception<void>(concurrencpp::result<void>, long) /home/runner/work/concurrencpp/concurrencpp/test/include/utils/test_ready_result.h:127:35 (result_tests+0xefc95)
    #2 void concurrencpp::tests::test_result_get_impl<void>() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:190:9 (result_tests+0xd8977) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #3 concurrencpp::tests::test_result_get() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:232:5 (result_tests+0xd1e89) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #4 decltype(std::declval<void (*&)()>()()) std::__1::__invoke[abi:v15002]<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (result_tests+0x10[246](https://github.com/chausner/concurrencpp/actions/runs/3166664285/jobs/5156524168#step:11:247)9) (BuildId: c583e150ef9e5c8fc4981[248](https://github.com/chausner/concurrencpp/actions/runs/3166664285/jobs/5156524168#step:11:249)53505de15fb29635)
    #5 void std::__1::__invoke_void_return_wrapper<void, true>::__call<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:479:9 (result_tests+0x102469)
    #6 std::__1::__function::__alloc_func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()[abi:v15002]() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:185:16 (result_tests+0x102469)
    #7 std::__1::__function::__func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:359:12 (result_tests+0x102469)
    #8 std::__1::__function::__value_func<void ()>::operator()[abi:v15002]() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:512:16 (result_tests+0x104562) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #9 std::__1::function<void ()>::operator()() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:1187:12 (result_tests+0x104562)
    #10 concurrencpp::tests::test_step::launch_test_step() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:16:5 (result_tests+0x104562)
    #11 concurrencpp::tests::tester::launch_test() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:33:23 (result_tests+0x10484c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #12 main /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:725:12 (result_tests+0xd246c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)

  Thread T6 (tid=5737, running) created by main thread at:
    #0 pthread_create <null> (result_tests+0x50e0d) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #1 std::__1::__libcpp_thread_create[abi:v15002](unsigned long*, void* (*)(void*), void*) /usr/lib/llvm-15/bin/../include/c++/v1/__threading_support:376:10 (result_tests+0xefa77) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #2 std::__1::thread::thread<void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'(), void>(void concurrencpp::tests::test_result_get_impl<void>()::'lambda1'()&&) /usr/lib/llvm-15/bin/../include/c++/v1/thread:311:16 (result_tests+0xefa77)
    #3 void concurrencpp::tests::test_result_get_impl<void>() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:179:21 (result_tests+0xd8890) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #4 concurrencpp::tests::test_result_get() /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:232:5 (result_tests+0xd1e89) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #5 decltype(std::declval<void (*&)()>()()) std::__1::__invoke[abi:v15002]<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:394:23 (result_tests+0x102469) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #6 void std::__1::__invoke_void_return_wrapper<void, true>::__call<void (*&)()>(void (*&)()) /usr/lib/llvm-15/bin/../include/c++/v1/__functional/invoke.h:479:9 (result_tests+0x102469)
    #7 std::__1::__function::__alloc_func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()[abi:v15002]() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:185:16 (result_tests+0x102469)
    #8 std::__1::__function::__func<void (*)(), std::__1::allocator<void (*)()>, void ()>::operator()() /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:359:12 (result_tests+0x102469)
    #9 std::__1::__function::__value_func<void ()>::operator()[abi:v15002]() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:512:16 (result_tests+0x104562) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #10 std::__1::function<void ()>::operator()() const /usr/lib/llvm-15/bin/../include/c++/v1/__functional/function.h:1187:12 (result_tests+0x104562)
    #11 concurrencpp::tests::test_step::launch_test_step() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:16:5 (result_tests+0x104562)
    #12 concurrencpp::tests::tester::launch_test() /home/runner/work/concurrencpp/concurrencpp/test/source/infra/tester.cpp:33:23 (result_tests+0x10484c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)
    #13 main /home/runner/work/concurrencpp/concurrencpp/test/source/tests/result_tests/result_tests.cpp:725:12 (result_tests+0xd246c) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635)

SUMMARY: ThreadSanitizer: data race (/home/runner/work/concurrencpp/concurrencpp/build/test/result_tests+0x4fc94) (BuildId: c583e150ef9e5c8fc498124853505de15fb29635) in free
==================
	Test-step ended (1590ms).
	Test-step started: wait
	Test-step ended (1755ms).
	Test-step started: wait_for
	Test-step ended ([251](https://github.com/chausner/concurrencpp/actions/runs/3166664285/jobs/5156524168#step:11:252)1ms).
	Test-step started: wait_until
	Test-step ended ([253](https://github.com/chausner/concurrencpp/actions/runs/3166664285/jobs/5156524168#step:11:254)3ms).
	Test-step started: operator =
	Test-step ended (0ms).
Test ended.
____________________
ThreadSanitizer: reported 1 warnings
```

</details>