### PR TITLE
Add thread_started_callback and thread_terminated_callback

### DIFF
--- a/include/concurrencpp/executors/constants.h
+++ b/include/concurrencpp/executors/constants.h
@@ -19,6 +19,8 @@ namespace concurrencpp::details::consts {
     inline const char* k_manual_executor_name = "concurrencpp::manual_executor";
     constexpr int k_manual_executor_max_concurrency_level = std::numeric_limits<int>::max();
 
+    inline const char* k_timer_queue_name = "concurrencpp::timer_queue";
+
     inline const char* k_executor_shutdown_err_msg = " - shutdown has been called on this executor.";
 }  // namespace concurrencpp::details::consts
 

--- a/include/concurrencpp/executors/executor.h
+++ b/include/concurrencpp/executors/executor.h
@@ -11,7 +11,7 @@
 
 namespace concurrencpp::details {
     [[noreturn]] CRCPP_API void throw_runtime_shutdown_exception(std::string_view executor_name);
-    std::string make_executor_worker_name(std::string_view executor_name);
+    CRCPP_API std::string make_executor_worker_name(std::string_view executor_name);
 }  // namespace concurrencpp::details
 
 namespace concurrencpp {
@@ -35,7 +35,7 @@ namespace concurrencpp {
 
             void await_suspend(details::coroutine_handle<void> coro_handle) noexcept {
                 try {
-                    accumulator.emplace_back(details::await_via_functor(coro_handle, &m_interrupted));                                   
+                    accumulator.emplace_back(details::await_via_functor(coro_handle, &m_interrupted));
                 } catch (...) {
                     // do nothing. ~await_via_functor will resume the coroutine and throw an exception.
                 }

--- a/include/concurrencpp/executors/thread_executor.h
+++ b/include/concurrencpp/executors/thread_executor.h
@@ -20,12 +20,15 @@ namespace concurrencpp {
         std::list<details::thread> m_last_retired;
         bool m_abort;
         std::atomic_bool m_atomic_abort;
+        std::function<void(const char* thread_name)> m_thread_started_callback;
+        std::function<void(const char* thread_name)> m_thread_terminated_callback;
 
         void enqueue_impl(std::unique_lock<std::mutex>& lock, task& task);
         void retire_worker(std::list<details::thread>::iterator it);
 
        public:
-        thread_executor();
+        thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
+                        const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
         ~thread_executor() noexcept;
 
         void enqueue(task task) override;

--- a/include/concurrencpp/executors/thread_executor.h
+++ b/include/concurrencpp/executors/thread_executor.h
@@ -20,8 +20,8 @@ namespace concurrencpp {
         std::list<details::thread> m_last_retired;
         bool m_abort;
         std::atomic_bool m_atomic_abort;
-        std::function<void(std::string_view thread_name)> m_thread_started_callback;
-        std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
+        const std::function<void(std::string_view thread_name)> m_thread_started_callback;
+        const std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
 
         void enqueue_impl(std::unique_lock<std::mutex>& lock, task& task);
         void retire_worker(std::list<details::thread>::iterator it);

--- a/include/concurrencpp/executors/thread_executor.h
+++ b/include/concurrencpp/executors/thread_executor.h
@@ -20,15 +20,15 @@ namespace concurrencpp {
         std::list<details::thread> m_last_retired;
         bool m_abort;
         std::atomic_bool m_atomic_abort;
-        std::function<void(const char* thread_name)> m_thread_started_callback;
-        std::function<void(const char* thread_name)> m_thread_terminated_callback;
+        std::function<void(std::string_view thread_name)> m_thread_started_callback;
+        std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
 
         void enqueue_impl(std::unique_lock<std::mutex>& lock, task& task);
         void retire_worker(std::list<details::thread>::iterator it);
 
        public:
-        thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
-                        const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
+        thread_executor(const std::function<void(std::string_view thread_name)>& thread_started_callback = {},
+                        const std::function<void(std::string_view thread_name)>& thread_terminated_callback = {});
         ~thread_executor() noexcept;
 
         void enqueue(task task) override;

--- a/include/concurrencpp/executors/thread_pool_executor.h
+++ b/include/concurrencpp/executors/thread_pool_executor.h
@@ -60,8 +60,8 @@ namespace concurrencpp {
         thread_pool_executor(std::string_view pool_name,
                              size_t pool_size,
                              std::chrono::milliseconds max_idle_time,
-                             const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
-                             const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
+                             const std::function<void(std::string_view thread_name)>& thread_started_callback = {},
+                             const std::function<void(std::string_view thread_name)>& thread_terminated_callback = {});
 
         ~thread_pool_executor() override;
 

--- a/include/concurrencpp/executors/thread_pool_executor.h
+++ b/include/concurrencpp/executors/thread_pool_executor.h
@@ -57,7 +57,11 @@ namespace concurrencpp {
         details::thread_pool_worker& worker_at(size_t index) noexcept;
 
        public:
-        thread_pool_executor(std::string_view pool_name, size_t pool_size, std::chrono::milliseconds max_idle_time);
+        thread_pool_executor(std::string_view pool_name,
+                             size_t pool_size,
+                             std::chrono::milliseconds max_idle_time,
+                             const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
+                             const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
 
         ~thread_pool_executor() override;
 

--- a/include/concurrencpp/executors/worker_thread_executor.h
+++ b/include/concurrencpp/executors/worker_thread_executor.h
@@ -35,7 +35,8 @@ namespace concurrencpp {
         void enqueue_foreign(std::span<concurrencpp::task> task);
 
        public:
-        worker_thread_executor();
+        worker_thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
+                               const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
 
         void enqueue(concurrencpp::task task) override;
         void enqueue(std::span<concurrencpp::task> tasks) override;

--- a/include/concurrencpp/executors/worker_thread_executor.h
+++ b/include/concurrencpp/executors/worker_thread_executor.h
@@ -35,8 +35,8 @@ namespace concurrencpp {
         void enqueue_foreign(std::span<concurrencpp::task> task);
 
        public:
-        worker_thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
-                               const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
+        worker_thread_executor(const std::function<void(std::string_view thread_name)>& thread_started_callback = {},
+                               const std::function<void(std::string_view thread_name)>& thread_terminated_callback = {});
 
         void enqueue(concurrencpp::task task) override;
         void enqueue(std::span<concurrencpp::task> tasks) override;

--- a/include/concurrencpp/runtime/runtime.h
+++ b/include/concurrencpp/runtime/runtime.h
@@ -34,8 +34,8 @@ namespace concurrencpp {
 
         std::chrono::milliseconds max_timer_queue_waiting_time;
 
-        std::function<void(const char* thread_name)> thread_started_callback;
-        std::function<void(const char* thread_name)> thread_terminated_callback;
+        std::function<void(std::string_view thread_name)> thread_started_callback;
+        std::function<void(std::string_view thread_name)> thread_terminated_callback;
 
         runtime_options() noexcept;
 

--- a/include/concurrencpp/runtime/runtime.h
+++ b/include/concurrencpp/runtime/runtime.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <vector>
 #include <chrono>
+#include <functional>
 
 namespace concurrencpp::details {
     class CRCPP_API executor_collection {
@@ -32,6 +33,9 @@ namespace concurrencpp {
         std::chrono::milliseconds max_background_executor_waiting_time;
 
         std::chrono::milliseconds max_timer_queue_waiting_time;
+
+        std::function<void(const char* thread_name)> thread_started_callback;
+        std::function<void(const char* thread_name)> thread_terminated_callback;
 
         runtime_options() noexcept;
 

--- a/include/concurrencpp/threads/thread.h
+++ b/include/concurrencpp/threads/thread.h
@@ -30,14 +30,14 @@ namespace concurrencpp::details {
                                     thread_terminated_callback = std::move(thread_terminated_callback)]() mutable {
                 set_name(name);
 
-                if (thread_started_callback) {
-                    thread_started_callback(name.c_str());
+                if (static_cast<bool>(thread_started_callback)) {
+                    thread_started_callback(name);
                 }
 
                 callable();
 
-                if (thread_terminated_callback) {
-                    thread_terminated_callback(name.c_str());
+                if (static_cast<bool>(thread_terminated_callback)) {
+                    thread_terminated_callback(name);
                 }
             });
         }

--- a/include/concurrencpp/threads/thread.h
+++ b/include/concurrencpp/threads/thread.h
@@ -22,21 +22,23 @@ namespace concurrencpp::details {
         template<class callable_type>
         thread(std::string name,
                callable_type&& callable,
-               std::function<void(const char* thread_name)> thread_started_callback,
-               std::function<void(const char* thread_name)> thread_terminated_callback) {
+               std::function<void(std::string_view thread_name)> thread_started_callback,
+               std::function<void(std::string_view thread_name)> thread_terminated_callback) {
             m_thread = std::thread([name = std::move(name),
                                     callable = std::forward<callable_type>(callable),
                                     thread_started_callback = std::move(thread_started_callback),
                                     thread_terminated_callback = std::move(thread_terminated_callback)]() mutable {
                 set_name(name);
 
-                if (thread_started_callback)
+                if (thread_started_callback) {
                     thread_started_callback(name.c_str());
+                }
 
                 callable();
 
-                if (thread_terminated_callback)
+                if (thread_terminated_callback) {
                     thread_terminated_callback(name.c_str());
+                }
             });
         }
 

--- a/include/concurrencpp/timers/timer_queue.h
+++ b/include/concurrencpp/timers/timer_queue.h
@@ -40,8 +40,8 @@ namespace concurrencpp {
         bool m_abort;
         bool m_idle;
         const std::chrono::milliseconds m_max_waiting_time;
-        std::function<void(const char* thread_name)> m_thread_started_callback;
-        std::function<void(const char* thread_name)> m_thread_terminated_callback;
+        std::function<void(std::string_view thread_name)> m_thread_started_callback;
+        std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
 
         details::thread ensure_worker_thread(std::unique_lock<std::mutex>& lock);
 
@@ -82,8 +82,8 @@ namespace concurrencpp {
 
        public:
         timer_queue(std::chrono::milliseconds max_waiting_time,
-                    const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
-                    const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
+                    const std::function<void(std::string_view thread_name)>& thread_started_callback = {},
+                    const std::function<void(std::string_view thread_name)>& thread_terminated_callback = {});
         ~timer_queue() noexcept;
 
         void shutdown();

--- a/include/concurrencpp/timers/timer_queue.h
+++ b/include/concurrencpp/timers/timer_queue.h
@@ -40,6 +40,8 @@ namespace concurrencpp {
         bool m_abort;
         bool m_idle;
         const std::chrono::milliseconds m_max_waiting_time;
+        std::function<void(const char* thread_name)> m_thread_started_callback;
+        std::function<void(const char* thread_name)> m_thread_terminated_callback;
 
         details::thread ensure_worker_thread(std::unique_lock<std::mutex>& lock);
 
@@ -79,7 +81,9 @@ namespace concurrencpp {
         void work_loop();
 
        public:
-        timer_queue(std::chrono::milliseconds max_waiting_time);
+        timer_queue(std::chrono::milliseconds max_waiting_time,
+                    const std::function<void(const char* thread_name)>& thread_started_callback = nullptr,
+                    const std::function<void(const char* thread_name)>& thread_terminated_callback = nullptr);
         ~timer_queue() noexcept;
 
         void shutdown();

--- a/include/concurrencpp/timers/timer_queue.h
+++ b/include/concurrencpp/timers/timer_queue.h
@@ -40,8 +40,8 @@ namespace concurrencpp {
         bool m_abort;
         bool m_idle;
         const std::chrono::milliseconds m_max_waiting_time;
-        std::function<void(std::string_view thread_name)> m_thread_started_callback;
-        std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
+        const std::function<void(std::string_view thread_name)> m_thread_started_callback;
+        const std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
 
         details::thread ensure_worker_thread(std::unique_lock<std::mutex>& lock);
 

--- a/source/executors/thread_executor.cpp
+++ b/source/executors/thread_executor.cpp
@@ -3,9 +3,11 @@
 
 using concurrencpp::thread_executor;
 
-thread_executor::thread_executor() :
-    derivable_executor<concurrencpp::thread_executor>(details::consts::k_thread_executor_name), m_abort(false), m_atomic_abort(false) {
-}
+thread_executor::thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback,
+                                 const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+    derivable_executor<concurrencpp::thread_executor>(details::consts::k_thread_executor_name),
+    m_abort(false), m_atomic_abort(false), m_thread_started_callback(thread_started_callback),
+    m_thread_terminated_callback(thread_terminated_callback) {}
 
 thread_executor::~thread_executor() noexcept {
     assert(m_workers.empty());
@@ -16,11 +18,14 @@ void thread_executor::enqueue_impl(std::unique_lock<std::mutex>& lock, concurren
     assert(lock.owns_lock());
 
     auto& new_thread = m_workers.emplace_front();
-    new_thread = details::thread(details::make_executor_worker_name(name),
-                                 [this, self_it = m_workers.begin(), task = std::move(task)]() mutable {
-                                     task();
-                                     retire_worker(self_it);
-                                 });
+    new_thread = details::thread(
+        details::make_executor_worker_name(name),
+        [this, self_it = m_workers.begin(), task = std::move(task)]() mutable {
+            task();
+            retire_worker(self_it);
+        },
+        m_thread_started_callback,
+        m_thread_terminated_callback);
 }
 
 void thread_executor::enqueue(concurrencpp::task task) {

--- a/source/executors/thread_executor.cpp
+++ b/source/executors/thread_executor.cpp
@@ -3,8 +3,8 @@
 
 using concurrencpp::thread_executor;
 
-thread_executor::thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback,
-                                 const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+thread_executor::thread_executor(const std::function<void(std::string_view thread_name)>& thread_started_callback,
+                                 const std::function<void(std::string_view thread_name)>& thread_terminated_callback) :
     derivable_executor<concurrencpp::thread_executor>(details::consts::k_thread_executor_name),
     m_abort(false), m_atomic_abort(false), m_thread_started_callback(thread_started_callback),
     m_thread_terminated_callback(thread_terminated_callback) {}

--- a/source/executors/thread_pool_executor.cpp
+++ b/source/executors/thread_pool_executor.cpp
@@ -45,8 +45,8 @@ namespace concurrencpp::details {
         bool m_abort;
         std::atomic_bool m_task_found_or_abort;
         thread m_thread;
-        std::function<void(const char* thread_name)> m_thread_started_callback;
-        std::function<void(const char* thread_name)> m_thread_terminated_callback;
+        std::function<void(std::string_view thread_name)> m_thread_started_callback;
+        std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
 
         void balance_work();
 
@@ -63,8 +63,8 @@ namespace concurrencpp::details {
                            size_t index,
                            size_t pool_size,
                            std::chrono::milliseconds max_idle_time,
-                           const std::function<void(const char* thread_name)>& thread_started_callback,
-                           const std::function<void(const char* thread_name)>& thread_terminated_callback);
+                           const std::function<void(std::string_view thread_name)>& thread_started_callback,
+                           const std::function<void(std::string_view thread_name)>& thread_terminated_callback);
 
         thread_pool_worker(thread_pool_worker&& rhs) noexcept;
         ~thread_pool_worker() noexcept;
@@ -173,8 +173,8 @@ thread_pool_worker::thread_pool_worker(thread_pool_executor& parent_pool,
                                        size_t index,
                                        size_t pool_size,
                                        std::chrono::milliseconds max_idle_time,
-                                       const std::function<void(const char* thread_name)>& thread_started_callback,
-                                       const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+                                       const std::function<void(std::string_view thread_name)>& thread_started_callback,
+                                       const std::function<void(std::string_view thread_name)>& thread_terminated_callback) :
     m_atomic_abort(false),
     m_parent_pool(parent_pool), m_index(index), m_pool_size(pool_size), m_max_idle_time(max_idle_time),
     m_worker_name(details::make_executor_worker_name(parent_pool.name)), m_semaphore(0), m_idle(true), m_abort(false),
@@ -518,8 +518,8 @@ bool thread_pool_worker::appears_empty() const noexcept {
 thread_pool_executor::thread_pool_executor(std::string_view pool_name,
                                            size_t pool_size,
                                            std::chrono::milliseconds max_idle_time,
-                                           const std::function<void(const char* thread_name)>& thread_started_callback,
-                                           const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+                                           const std::function<void(std::string_view thread_name)>& thread_started_callback,
+                                           const std::function<void(std::string_view thread_name)>& thread_terminated_callback) :
     derivable_executor<concurrencpp::thread_pool_executor>(pool_name),
     m_round_robin_cursor(0), m_idle_workers(pool_size), m_abort(false) {
     m_workers.reserve(pool_size);

--- a/source/executors/thread_pool_executor.cpp
+++ b/source/executors/thread_pool_executor.cpp
@@ -165,11 +165,14 @@ void idle_worker_set::find_idle_workers(size_t caller_index, std::vector<size_t>
 thread_pool_worker::thread_pool_worker(thread_pool_executor& parent_pool,
                                        size_t index,
                                        size_t pool_size,
-                                       std::chrono::milliseconds max_idle_time) :
+                                       std::chrono::milliseconds max_idle_time,
+                                       const std::function<void(const char* thread_name)>& thread_started_callback,
+                                       const std::function<void(const char* thread_name)>& thread_terminated_callback) :
     m_atomic_abort(false),
     m_parent_pool(parent_pool), m_index(index), m_pool_size(pool_size), m_max_idle_time(max_idle_time),
     m_worker_name(details::make_executor_worker_name(parent_pool.name)), m_semaphore(0), m_idle(true), m_abort(false),
-    m_task_found_or_abort(false) {
+    m_task_found_or_abort(false), m_thread_started_callback(thread_started_callback),
+    m_thread_terminated_callback(thread_terminated_callback) {
     m_idle_worker_list.reserve(pool_size);
 }
 
@@ -383,9 +386,13 @@ void thread_pool_worker::ensure_worker_active(bool first_enqueuer, std::unique_l
     }
 
     auto stale_worker = std::move(m_thread);
-    m_thread = thread(m_worker_name, [this] {
-        work_loop();
-    });
+    m_thread = thread(
+        m_worker_name,
+        [this] {
+            work_loop();
+        },
+        m_thread_started_callback,
+        m_thread_terminated_callback);
 
     m_idle = false;
     lock.unlock();
@@ -501,13 +508,17 @@ bool thread_pool_worker::appears_empty() const noexcept {
     return m_private_queue.empty() && !m_task_found_or_abort.load(std::memory_order_relaxed);
 }
 
-thread_pool_executor::thread_pool_executor(std::string_view pool_name, size_t pool_size, std::chrono::milliseconds max_idle_time) :
-    derivable_executor<concurrencpp::thread_pool_executor>(pool_name), m_round_robin_cursor(0), m_idle_workers(pool_size),
-    m_abort(false) {
+thread_pool_executor::thread_pool_executor(std::string_view pool_name,
+                                           size_t pool_size,
+                                           std::chrono::milliseconds max_idle_time,
+                                           const std::function<void(const char* thread_name)>& thread_started_callback,
+                                           const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+    derivable_executor<concurrencpp::thread_pool_executor>(pool_name),
+    m_round_robin_cursor(0), m_idle_workers(pool_size), m_abort(false) {
     m_workers.reserve(pool_size);
 
     for (size_t i = 0; i < pool_size; i++) {
-        m_workers.emplace_back(*this, i, pool_size, max_idle_time);
+        m_workers.emplace_back(*this, i, pool_size, max_idle_time, thread_started_callback, thread_terminated_callback);
     }
 
     for (size_t i = 0; i < pool_size; i++) {

--- a/source/executors/thread_pool_executor.cpp
+++ b/source/executors/thread_pool_executor.cpp
@@ -45,8 +45,8 @@ namespace concurrencpp::details {
         bool m_abort;
         std::atomic_bool m_task_found_or_abort;
         thread m_thread;
-        std::function<void(std::string_view thread_name)> m_thread_started_callback;
-        std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
+        const std::function<void(std::string_view thread_name)> m_thread_started_callback;
+        const std::function<void(std::string_view thread_name)> m_thread_terminated_callback;
 
         void balance_work();
 

--- a/source/executors/thread_pool_executor.cpp
+++ b/source/executors/thread_pool_executor.cpp
@@ -45,6 +45,8 @@ namespace concurrencpp::details {
         bool m_abort;
         std::atomic_bool m_task_found_or_abort;
         thread m_thread;
+        std::function<void(const char* thread_name)> m_thread_started_callback;
+        std::function<void(const char* thread_name)> m_thread_terminated_callback;
 
         void balance_work();
 
@@ -57,7 +59,12 @@ namespace concurrencpp::details {
         void ensure_worker_active(bool first_enqueuer, std::unique_lock<std::mutex>& lock);
 
        public:
-        thread_pool_worker(thread_pool_executor& parent_pool, size_t index, size_t pool_size, std::chrono::milliseconds max_idle_time);
+        thread_pool_worker(thread_pool_executor& parent_pool,
+                           size_t index,
+                           size_t pool_size,
+                           std::chrono::milliseconds max_idle_time,
+                           const std::function<void(const char* thread_name)>& thread_started_callback,
+                           const std::function<void(const char* thread_name)>& thread_terminated_callback);
 
         thread_pool_worker(thread_pool_worker&& rhs) noexcept;
         ~thread_pool_worker() noexcept;

--- a/source/executors/worker_thread_executor.cpp
+++ b/source/executors/worker_thread_executor.cpp
@@ -7,8 +7,8 @@ namespace concurrencpp::details {
 
 using concurrencpp::worker_thread_executor;
 
-worker_thread_executor::worker_thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback,
-                                               const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+worker_thread_executor::worker_thread_executor(const std::function<void(std::string_view thread_name)>& thread_started_callback,
+                                               const std::function<void(std::string_view thread_name)>& thread_terminated_callback) :
     derivable_executor<concurrencpp::worker_thread_executor>(details::consts::k_worker_thread_executor_name),
     m_private_atomic_abort(false), m_semaphore(0), m_atomic_abort(false), m_abort(false) {
     m_thread = details::thread(

--- a/source/executors/worker_thread_executor.cpp
+++ b/source/executors/worker_thread_executor.cpp
@@ -7,12 +7,17 @@ namespace concurrencpp::details {
 
 using concurrencpp::worker_thread_executor;
 
-worker_thread_executor::worker_thread_executor() :
+worker_thread_executor::worker_thread_executor(const std::function<void(const char* thread_name)>& thread_started_callback,
+                                               const std::function<void(const char* thread_name)>& thread_terminated_callback) :
     derivable_executor<concurrencpp::worker_thread_executor>(details::consts::k_worker_thread_executor_name),
     m_private_atomic_abort(false), m_semaphore(0), m_atomic_abort(false), m_abort(false) {
-    m_thread = details::thread(details::make_executor_worker_name(name), [this] {
-        work_loop();
-    });
+    m_thread = details::thread(
+        details::make_executor_worker_name(name),
+        [this] {
+            work_loop();
+        },
+        thread_started_callback,
+        thread_terminated_callback);
 }
 
 bool worker_thread_executor::drain_queue_impl() {

--- a/source/runtime/runtime.cpp
+++ b/source/runtime/runtime.cpp
@@ -77,15 +77,20 @@ runtime::runtime(const runtime_options& options) {
 
     m_thread_pool_executor = std::make_shared<::concurrencpp::thread_pool_executor>(details::consts::k_thread_pool_executor_name,
                                                                                     options.max_cpu_threads,
-                                                                                    options.max_thread_pool_executor_waiting_time);
+                                                                                    options.max_thread_pool_executor_waiting_time,
+                                                                                    options.thread_started_callback,
+                                                                                    options.thread_terminated_callback);
     m_registered_executors.register_executor(m_thread_pool_executor);
 
     m_background_executor = std::make_shared<::concurrencpp::thread_pool_executor>(details::consts::k_background_executor_name,
                                                                                    options.max_background_threads,
-                                                                                   options.max_background_executor_waiting_time);
+                                                                                   options.max_background_executor_waiting_time,
+                                                                                   options.thread_started_callback,
+                                                                                   options.thread_terminated_callback);
     m_registered_executors.register_executor(m_background_executor);
 
-    m_thread_executor = std::make_shared<::concurrencpp::thread_executor>();
+    m_thread_executor =
+        std::make_shared<::concurrencpp::thread_executor>(options.thread_started_callback, options.thread_terminated_callback);
     m_registered_executors.register_executor(m_thread_executor);
 }
 

--- a/source/runtime/runtime.cpp
+++ b/source/runtime/runtime.cpp
@@ -70,7 +70,9 @@ runtime_options::runtime_options() noexcept :
 runtime::runtime() : runtime(runtime_options()) {}
 
 runtime::runtime(const runtime_options& options) {
-    m_timer_queue = std::make_shared<::concurrencpp::timer_queue>(options.max_timer_queue_waiting_time);
+    m_timer_queue = std::make_shared<::concurrencpp::timer_queue>(options.max_timer_queue_waiting_time,
+                                                                  options.thread_started_callback,
+                                                                  options.thread_terminated_callback);
 
     m_inline_executor = std::make_shared<::concurrencpp::inline_executor>();
     m_registered_executors.register_executor(m_inline_executor);

--- a/source/timers/timer_queue.cpp
+++ b/source/timers/timer_queue.cpp
@@ -2,6 +2,8 @@
 #include "concurrencpp/timers/timer_queue.h"
 
 #include "concurrencpp/coroutines/coroutine.h"
+#include "concurrencpp/executors/constants.h"
+#include "concurrencpp/executors/executor.h"
 
 #include <set>
 #include <unordered_map>
@@ -258,7 +260,7 @@ concurrencpp::details::thread timer_queue::ensure_worker_thread(std::unique_lock
     auto old_worker = std::move(m_worker);
 
     m_worker = details::thread(
-        "concurrencpp::timer_queue worker",
+        details::make_executor_worker_name(details::consts::k_timer_queue_name),
         [this] {
             work_loop();
         },

--- a/source/timers/timer_queue.cpp
+++ b/source/timers/timer_queue.cpp
@@ -146,8 +146,8 @@ namespace concurrencpp::details {
 }  // namespace concurrencpp::details
 
 timer_queue::timer_queue(milliseconds max_waiting_time,
-                         const std::function<void(const char* thread_name)>& thread_started_callback,
-                         const std::function<void(const char* thread_name)>& thread_terminated_callback) :
+                         const std::function<void(std::string_view thread_name)>& thread_started_callback,
+                         const std::function<void(std::string_view thread_name)>& thread_terminated_callback) :
     m_thread_started_callback(thread_started_callback),
     m_thread_terminated_callback(thread_terminated_callback), m_atomic_abort(false), m_abort(false), m_idle(true),
     m_max_waiting_time(max_waiting_time) {}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,7 +55,8 @@ set(test_headers
         include/utils/test_generators.h
         include/utils/throwing_executor.h
         include/utils/test_ready_result.h
-        include/utils/test_ready_lazy_result.h)
+        include/utils/test_ready_lazy_result.h
+        include/utils/test_thread_callbacks.h)
 
 add_library(concurrencpp_test_infra STATIC ${test_headers} ${test_sources})
 

--- a/test/include/utils/test_thread_callbacks.h
+++ b/test/include/utils/test_thread_callbacks.h
@@ -1,0 +1,41 @@
+#ifndef CONCURRENCPP_TEST_THREAD_CALLBACKS_H
+#define CONCURRENCPP_TEST_THREAD_CALLBACKS_H
+
+#include "infra/assertions.h"
+#include "concurrencpp/executors/executor.h"
+
+namespace concurrencpp::tests {
+    template<class executor_fabric_type>
+    void test_thread_callbacks(executor_fabric_type executor_fabric, std::string_view expected_thread_name) {
+        size_t thread_started_callback_invocations_num = 0;
+        size_t thread_terminated_callback_invocations_num = 0;
+
+        auto thread_started_callback = [&thread_started_callback_invocations_num, expected_thread_name](const char* thread_name) {
+            ++thread_started_callback_invocations_num;
+            assert_equal(thread_name, expected_thread_name);
+        };
+
+        auto thread_terminated_callback = [&thread_terminated_callback_invocations_num,
+                                           expected_thread_name](const char* thread_name) {
+            ++thread_terminated_callback_invocations_num;
+            assert_equal(thread_name, expected_thread_name);
+        };
+
+        std::shared_ptr<executor> executor = executor_fabric(thread_started_callback, thread_terminated_callback);
+        assert_equal(thread_started_callback_invocations_num, 0);
+        assert_equal(thread_terminated_callback_invocations_num, 0);
+
+        executor
+            ->submit([&thread_started_callback_invocations_num, &thread_terminated_callback_invocations_num]() {
+                assert_equal(thread_started_callback_invocations_num, 1);
+                assert_equal(thread_terminated_callback_invocations_num, 0);
+            })
+            .get();
+
+        executor->shutdown();
+        assert_equal(thread_started_callback_invocations_num, 1);
+        assert_equal(thread_terminated_callback_invocations_num, 1);
+    }
+}  // namespace concurrencpp::tests
+
+#endif

--- a/test/include/utils/test_thread_callbacks.h
+++ b/test/include/utils/test_thread_callbacks.h
@@ -5,23 +5,23 @@
 #include "concurrencpp/executors/executor.h"
 
 namespace concurrencpp::tests {
-    template<class executor_fabric_type>
-    void test_thread_callbacks(executor_fabric_type executor_fabric, std::string_view expected_thread_name) {
-        size_t thread_started_callback_invocations_num = 0;
-        size_t thread_terminated_callback_invocations_num = 0;
+    template<class executor_factory_type>
+    void test_thread_callbacks(executor_factory_type executor_factory, std::string_view expected_thread_name) {
+        std::atomic_size_t thread_started_callback_invocations_num = 0;
+        std::atomic_size_t thread_terminated_callback_invocations_num = 0;
 
-        auto thread_started_callback = [&thread_started_callback_invocations_num, expected_thread_name](const char* thread_name) {
+        auto thread_started_callback = [&thread_started_callback_invocations_num, expected_thread_name](std::string_view thread_name) {
             ++thread_started_callback_invocations_num;
             assert_equal(thread_name, expected_thread_name);
         };
 
         auto thread_terminated_callback = [&thread_terminated_callback_invocations_num,
-                                           expected_thread_name](const char* thread_name) {
+                                           expected_thread_name](std::string_view thread_name) {
             ++thread_terminated_callback_invocations_num;
             assert_equal(thread_name, expected_thread_name);
         };
 
-        std::shared_ptr<executor> executor = executor_fabric(thread_started_callback, thread_terminated_callback);
+        std::shared_ptr<executor> executor = executor_factory(thread_started_callback, thread_terminated_callback);
         assert_equal(thread_started_callback_invocations_num, 0);
         assert_equal(thread_terminated_callback_invocations_num, 0);
 

--- a/test/source/tests/executor_tests/thread_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_executor_tests.cpp
@@ -6,6 +6,7 @@
 #include "utils/test_generators.h"
 #include "utils/test_ready_result.h"
 #include "utils/executor_shutdowner.h"
+#include "utils/test_thread_callbacks.h"
 
 namespace concurrencpp::tests {
     void test_thread_executor_name();
@@ -36,6 +37,8 @@ namespace concurrencpp::tests {
     void test_thread_executor_bulk_submit_foreign();
     void test_thread_executor_bulk_submit_inline();
     void test_thread_executor_bulk_submit();
+
+    void test_thread_executor_thread_callbacks();
 
     void assert_unique_execution_threads(const std::unordered_map<size_t, size_t>& execution_map, const size_t expected_thread_count) {
         assert_equal(execution_map.size(), expected_thread_count);
@@ -373,6 +376,14 @@ void concurrencpp::tests::test_thread_executor_bulk_submit() {
     test_thread_executor_bulk_post_inline();
 }
 
+void concurrencpp::tests::test_thread_executor_thread_callbacks() {
+    test_thread_callbacks(
+        [](auto thread_started_callback, auto thread_terminated_callback) {
+            return std::make_shared<thread_executor>(thread_started_callback, thread_terminated_callback);
+        },
+        concurrencpp::details::make_executor_worker_name(concurrencpp::details::consts::k_thread_executor_name));
+}
+
 using namespace concurrencpp::tests;
 
 int main() {
@@ -385,6 +396,7 @@ int main() {
     tester.add_step("submit", test_thread_executor_submit);
     tester.add_step("bulk_post", test_thread_executor_bulk_post);
     tester.add_step("bulk_submit", test_thread_executor_bulk_submit);
+    tester.add_step("thread_callbacks", test_thread_executor_thread_callbacks);
 
     tester.launch_test();
     return 0;

--- a/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
@@ -553,7 +553,7 @@ void concurrencpp::tests::test_thread_pool_executor_dynamic_resizing() {
 void concurrencpp::tests::test_thread_pool_executor_thread_callbacks() {
     constexpr std::string_view thread_pool_name = "threadpool";
     test_thread_callbacks(
-        [](auto thread_started_callback, auto thread_terminated_callback) {
+        [thread_pool_name](auto thread_started_callback, auto thread_terminated_callback) {
             return std::make_shared<thread_pool_executor>(thread_pool_name,
                                                           1,
                                                           std::chrono::seconds(10),

--- a/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
+++ b/test/source/tests/executor_tests/thread_pool_executor_tests.cpp
@@ -6,6 +6,7 @@
 #include "utils/test_generators.h"
 #include "utils/test_ready_result.h"
 #include "utils/executor_shutdowner.h"
+#include "utils/test_thread_callbacks.h"
 
 namespace concurrencpp::tests {
     void test_thread_pool_executor_name();
@@ -37,6 +38,8 @@ namespace concurrencpp::tests {
 
     void test_thread_pool_executor_enqueue_algorithm();
     void test_thread_pool_executor_dynamic_resizing();
+
+    void test_thread_pool_executor_thread_callbacks();
 }  // namespace concurrencpp::tests
 
 using concurrencpp::details::thread;
@@ -547,6 +550,19 @@ void concurrencpp::tests::test_thread_pool_executor_dynamic_resizing() {
     }
 }
 
+void concurrencpp::tests::test_thread_pool_executor_thread_callbacks() {
+    constexpr std::string_view thread_pool_name = "threadpool";
+    test_thread_callbacks(
+        [](auto thread_started_callback, auto thread_terminated_callback) {
+            return std::make_shared<thread_pool_executor>(thread_pool_name,
+                                                          1,
+                                                          std::chrono::seconds(10),
+                                                          thread_started_callback,
+                                                          thread_terminated_callback);
+        },
+        concurrencpp::details::make_executor_worker_name(thread_pool_name));
+}
+
 using namespace concurrencpp::tests;
 
 int main() {
@@ -560,6 +576,7 @@ int main() {
     tester.add_step("bulk_submit", test_thread_pool_executor_bulk_submit);
     tester.add_step("enqueuing algorithm", test_thread_pool_executor_enqueue_algorithm);
     tester.add_step("dynamic resizing", test_thread_pool_executor_dynamic_resizing);
+    tester.add_step("thread_callbacks", test_thread_pool_executor_thread_callbacks);
 
     tester.launch_test();
     return 0;

--- a/test/source/tests/executor_tests/worker_thread_executor_tests.cpp
+++ b/test/source/tests/executor_tests/worker_thread_executor_tests.cpp
@@ -6,6 +6,7 @@
 #include "utils/test_generators.h"
 #include "utils/test_ready_result.h"
 #include "utils/executor_shutdowner.h"
+#include "utils/test_thread_callbacks.h"
 
 namespace concurrencpp::tests {
     void test_worker_thread_executor_name();
@@ -36,6 +37,8 @@ namespace concurrencpp::tests {
     void test_worker_thread_executor_bulk_submit_foreign();
     void test_worker_thread_executor_bulk_submit_inline();
     void test_worker_thread_executor_bulk_submit();
+
+    void test_worker_thread_executor_thread_callbacks();
 
     void assert_unique_execution_thread(const std::unordered_map<size_t, size_t>& execution_map) {
         assert_equal(execution_map.size(), 1);
@@ -363,6 +366,14 @@ void concurrencpp::tests::test_worker_thread_executor_bulk_submit() {
     test_worker_thread_executor_bulk_submit_inline();
 }
 
+void concurrencpp::tests::test_worker_thread_executor_thread_callbacks() {
+    test_thread_callbacks(
+        [](auto thread_started_callback, auto thread_terminated_callback) {
+            return std::make_shared<worker_thread_executor>(thread_started_callback, thread_terminated_callback);
+        },
+        concurrencpp::details::make_executor_worker_name(concurrencpp::details::consts::k_worker_thread_executor_name));
+}
+
 using namespace concurrencpp::tests;
 
 int main() {
@@ -375,6 +386,7 @@ int main() {
     tester.add_step("submit", test_worker_thread_executor_submit);
     tester.add_step("bulk_post", test_worker_thread_executor_bulk_post);
     tester.add_step("bulk_submit", test_worker_thread_executor_bulk_submit);
+    tester.add_step("thread_callbacks", test_worker_thread_executor_thread_callbacks);
 
     tester.launch_test();
     return 0;

--- a/test/source/tests/runtime_tests.cpp
+++ b/test/source/tests/runtime_tests.cpp
@@ -40,6 +40,17 @@ void concurrencpp::tests::test_runtime_constructor() {
     opts.max_background_threads = 7;
     opts.max_background_executor_waiting_time = std::chrono::milliseconds(54321);
 
+    size_t thread_started_callback_invocations_num = 0;
+    size_t thread_terminated_callback_invocations_num = 0;
+
+    opts.thread_started_callback = [&thread_started_callback_invocations_num](const char* thread_name) {
+        ++thread_started_callback_invocations_num;
+    };
+
+    opts.thread_terminated_callback = [&thread_terminated_callback_invocations_num](const char* thread_name) {
+        ++thread_terminated_callback_invocations_num;
+    };
+
     concurrencpp::runtime runtime(opts);
     auto dummy_ex = runtime.make_executor<dummy_executor>("dummy_executor", 1, 4.4f);
     assert_true(static_cast<bool>(runtime.inline_executor()));
@@ -58,6 +69,30 @@ void concurrencpp::tests::test_runtime_constructor() {
     assert_equal(runtime.thread_pool_executor()->max_worker_idle_time(), opts.max_thread_pool_executor_waiting_time);
     assert_equal(runtime.background_executor()->max_concurrency_level(), opts.max_background_threads);
     assert_equal(runtime.background_executor()->max_worker_idle_time(), opts.max_background_executor_waiting_time);
+
+    auto test_runtime_executor = [&thread_started_callback_invocations_num,
+                                  &thread_terminated_callback_invocations_num](std::shared_ptr<executor> executor) {
+        size_t start_thread_started_callback_invocations_num = thread_started_callback_invocations_num;
+        size_t start_thread_terminated_callback_invocations_num = thread_terminated_callback_invocations_num;
+
+        executor
+            ->submit([&thread_started_callback_invocations_num,
+                      &thread_terminated_callback_invocations_num,
+                      start_thread_started_callback_invocations_num,
+                      start_thread_terminated_callback_invocations_num]() {
+                assert_equal(thread_started_callback_invocations_num, start_thread_started_callback_invocations_num + 1);
+                assert_equal(thread_terminated_callback_invocations_num, start_thread_terminated_callback_invocations_num);
+            })
+            .get();
+
+        executor->shutdown();
+        assert_equal(thread_started_callback_invocations_num, start_thread_started_callback_invocations_num + 1);
+        assert_equal(thread_terminated_callback_invocations_num, start_thread_terminated_callback_invocations_num + 1);
+    };
+
+    test_runtime_executor(runtime.thread_executor());
+    test_runtime_executor(runtime.thread_pool_executor());
+    test_runtime_executor(runtime.background_executor());
 }
 
 void concurrencpp::tests::test_runtime_destructor() {

--- a/test/source/tests/runtime_tests.cpp
+++ b/test/source/tests/runtime_tests.cpp
@@ -74,22 +74,19 @@ void concurrencpp::tests::test_runtime_constructor() {
 
     auto test_runtime_executor = [&thread_started_callback_invocations_num,
                                   &thread_terminated_callback_invocations_num](std::shared_ptr<executor> executor) {
-        size_t start_thread_started_callback_invocations_num = thread_started_callback_invocations_num;
-        size_t start_thread_terminated_callback_invocations_num = thread_terminated_callback_invocations_num;
+        thread_started_callback_invocations_num = 0;
+        thread_terminated_callback_invocations_num = 0;
 
         executor
-            ->submit([&thread_started_callback_invocations_num,
-                      &thread_terminated_callback_invocations_num,
-                      start_thread_started_callback_invocations_num,
-                      start_thread_terminated_callback_invocations_num]() {
-                assert_equal(thread_started_callback_invocations_num, start_thread_started_callback_invocations_num + 1);
-                assert_equal(thread_terminated_callback_invocations_num, start_thread_terminated_callback_invocations_num);
+            ->submit([&thread_started_callback_invocations_num, &thread_terminated_callback_invocations_num]() {
+                assert_equal(thread_started_callback_invocations_num, 1);
+                assert_equal(thread_terminated_callback_invocations_num, 0);
             })
             .get();
 
         executor->shutdown();
-        assert_equal(thread_started_callback_invocations_num, start_thread_started_callback_invocations_num + 1);
-        assert_equal(thread_terminated_callback_invocations_num, start_thread_terminated_callback_invocations_num + 1);
+        assert_equal(thread_started_callback_invocations_num, 1);
+        assert_equal(thread_terminated_callback_invocations_num, 1);
     };
 
     test_runtime_executor(runtime.thread_executor());

--- a/test/source/tests/runtime_tests.cpp
+++ b/test/source/tests/runtime_tests.cpp
@@ -40,14 +40,16 @@ void concurrencpp::tests::test_runtime_constructor() {
     opts.max_background_threads = 7;
     opts.max_background_executor_waiting_time = std::chrono::milliseconds(54321);
 
-    size_t thread_started_callback_invocations_num = 0;
-    size_t thread_terminated_callback_invocations_num = 0;
+    std::atomic_size_t thread_started_callback_invocations_num = 0;
+    std::atomic_size_t thread_terminated_callback_invocations_num = 0;
 
-    opts.thread_started_callback = [&thread_started_callback_invocations_num](const char* thread_name) {
+    opts.thread_started_callback = [&thread_started_callback_invocations_num](std::string_view thread_name) {
+        assert_false(thread_name.empty());
         ++thread_started_callback_invocations_num;
     };
 
-    opts.thread_terminated_callback = [&thread_terminated_callback_invocations_num](const char* thread_name) {
+    opts.thread_terminated_callback = [&thread_terminated_callback_invocations_num](std::string_view thread_name) {
+        assert_false(thread_name.empty());
         ++thread_terminated_callback_invocations_num;
     };
 

--- a/test/source/tests/timer_tests/timer_queue_tests.cpp
+++ b/test/source/tests/timer_tests/timer_queue_tests.cpp
@@ -109,15 +109,15 @@ void concurrencpp::tests::test_timer_queue_thread_injection() {
 }
 
 void concurrencpp::tests::test_timer_queue_thread_callbacks() {
-    size_t thread_started_callback_invocations_num = 0;
-    size_t thread_terminated_callback_invocations_num = 0;
+    std::atomic_size_t thread_started_callback_invocations_num = 0;
+    std::atomic_size_t thread_terminated_callback_invocations_num = 0;
 
-    auto thread_started_callback = [&thread_started_callback_invocations_num](const char* thread_name) {
+    auto thread_started_callback = [&thread_started_callback_invocations_num](std::string_view thread_name) {
         ++thread_started_callback_invocations_num;
         assert_equal(thread_name, concurrencpp::details::make_executor_worker_name(concurrencpp::details::consts::k_timer_queue_name));
     };
 
-    auto thread_terminated_callback = [&thread_terminated_callback_invocations_num](const char* thread_name) {
+    auto thread_terminated_callback = [&thread_terminated_callback_invocations_num](std::string_view thread_name) {
         ++thread_terminated_callback_invocations_num;
         assert_equal(thread_name, concurrencpp::details::make_executor_worker_name(concurrencpp::details::consts::k_timer_queue_name));
     };

--- a/test/source/tests/timer_tests/timer_queue_tests.cpp
+++ b/test/source/tests/timer_tests/timer_queue_tests.cpp
@@ -15,6 +15,7 @@ namespace concurrencpp::tests {
     void test_timer_queue_make_delay_object();
     void test_timer_queue_max_worker_idle_time();
     void test_timer_queue_thread_injection();
+    void test_timer_queue_thread_callbacks();
 }  // namespace concurrencpp::tests
 
 void concurrencpp::tests::test_timer_queue_make_timer() {
@@ -107,6 +108,40 @@ void concurrencpp::tests::test_timer_queue_thread_injection() {
     }
 }
 
+void concurrencpp::tests::test_timer_queue_thread_callbacks() {
+    size_t thread_started_callback_invocations_num = 0;
+    size_t thread_terminated_callback_invocations_num = 0;
+
+    auto thread_started_callback = [&thread_started_callback_invocations_num](const char* thread_name) {
+        ++thread_started_callback_invocations_num;
+        assert_equal(thread_name, concurrencpp::details::make_executor_worker_name(concurrencpp::details::consts::k_timer_queue_name));
+    };
+
+    auto thread_terminated_callback = [&thread_terminated_callback_invocations_num](const char* thread_name) {
+        ++thread_terminated_callback_invocations_num;
+        assert_equal(thread_name, concurrencpp::details::make_executor_worker_name(concurrencpp::details::consts::k_timer_queue_name));
+    };
+
+    auto timer_queue = std::make_shared<concurrencpp::timer_queue>(50ms, thread_started_callback, thread_terminated_callback);
+    assert_equal(thread_started_callback_invocations_num, 0);
+    assert_equal(thread_terminated_callback_invocations_num, 0);
+
+    auto inline_executor = std::make_shared<concurrencpp::inline_executor>();
+    executor_shutdowner es(inline_executor);
+
+    auto timer =
+        timer_queue->make_one_shot_timer(50ms,
+                                         inline_executor,
+                                         [&thread_started_callback_invocations_num, &thread_terminated_callback_invocations_num]() {
+                                             assert_equal(thread_started_callback_invocations_num, 1);
+                                             assert_equal(thread_terminated_callback_invocations_num, 0);
+                                         });
+
+    timer_queue->shutdown();
+    assert_equal(thread_started_callback_invocations_num, 1);
+    assert_equal(thread_terminated_callback_invocations_num, 1);
+}
+
 using namespace concurrencpp::tests;
 
 int main() {
@@ -116,7 +151,8 @@ int main() {
     test.add_step("make_oneshot_timer", test_timer_queue_make_timer);
     test.add_step("make_delay_object", test_timer_queue_make_delay_object);
     test.add_step("max_worker_idle_time", test_timer_queue_max_worker_idle_time);
-    test.add_step("thread injection", test_timer_queue_thread_injection);
+    test.add_step("thread_injection", test_timer_queue_thread_injection);
+    test.add_step("thread_callbacks", test_timer_queue_thread_callbacks);
 
     test.launch_test();
     return 0;


### PR DESCRIPTION
This pull request is adding thread_started_callback and thread_terminated_callback which are called when any internal concurrencpp thread is created. This feature is useful in several cases:
* Profiling. If you want to profile not only the main thread, but all async threads, you should register them in construction and unregister in destruction. This is very useful in gamedev. For example, I was able to do the following with Optick profiler:
![image](https://user-images.githubusercontent.com/30406125/209724972-44cbfc1b-9ff9-4607-a155-ae3eacee13c4.png)
* Custom general purpose allocator. For example, rpmalloc requires thread registration and unregistration as well