### PR TITLE
add interrupted_task for grouping broken_taks and runtime_shutdown

### DIFF
--- a/include/concurrencpp/errors.h
+++ b/include/concurrencpp/errors.h
@@ -28,15 +28,19 @@ namespace concurrencpp::errors {
         using empty_object::empty_object;
     };
 
-    struct broken_task : public std::runtime_error {
+    struct interrupted_task : public std::runtime_error {
         using runtime_error::runtime_error;
+    };
+
+    struct broken_task : public interrupted_task {
+        using interrupted_task::interrupted_task;
+    };
+
+    struct runtime_shutdown : public interrupted_task {
+        using interrupted_task::interrupted_task;
     };
 
     struct result_already_retrieved : public std::runtime_error {
-        using runtime_error::runtime_error;
-    };
-
-    struct runtime_shutdown : public std::runtime_error {
         using runtime_error::runtime_error;
     };
 }  // namespace concurrencpp::errors


### PR DESCRIPTION
As the readme stated:
`In any case where  a `runtime_shutdown` or a `broken_task` exception is thrown, applications should terminate their current code-flow gracefully as soon as possible.`
It is at the moment quite unpleasant of doing it because two different catch cases need to be handled. In my case, where I start to integrate std::stop_token, even a third exception will be established which already brings us to three cases.

Because of that, I found these changes very beneficial.