### PR TITLE
fix thread_pool_executor in shutdown situation

### DIFF
--- a/source/executors/thread_pool_executor.cpp
+++ b/source/executors/thread_pool_executor.cpp
@@ -357,15 +357,15 @@ void thread_pool_worker::work_loop() {
     s_tl_thread_pool_data.this_worker = this;
     s_tl_thread_pool_data.this_thread_index = m_index;
 
-    while (true) {
-        try {
+    try {
+        while (true) {
             if (!drain_queue()) {
                 return;
             }
-        } catch (const errors::runtime_shutdown&) {
-            m_idle = true;
-            return;
         }
+    } catch (const errors::runtime_shutdown&) {
+        std::unique_lock<std::mutex> lock(m_lock);
+        m_idle = true;
     }
 }
 

--- a/source/executors/thread_pool_executor.cpp
+++ b/source/executors/thread_pool_executor.cpp
@@ -358,7 +358,12 @@ void thread_pool_worker::work_loop() {
     s_tl_thread_pool_data.this_thread_index = m_index;
 
     while (true) {
-        if (!drain_queue()) {
+        try {
+            if (!drain_queue()) {
+                return;
+            }
+        } catch (const errors::runtime_shutdown&) {
+            m_idle = true;
             return;
         }
     }

--- a/source/executors/worker_thread_executor.cpp
+++ b/source/executors/worker_thread_executor.cpp
@@ -157,6 +157,7 @@ void worker_thread_executor::shutdown() {
         m_abort = true;
     }
 
+    m_private_atomic_abort.store(true, std::memory_order_relaxed);
     m_semaphore.release();
 
     if (m_thread.joinable()) {


### PR DESCRIPTION
In case a shutdown exception will be thrown, it was not handled within the threads. In case that happens, we need to catch it, because it can be expected, otherwise, the program terminates.

Where I am more insecure is the `worker_thread_executor`. Not sure about what `m_private_atomic_abort` is doing here, but it was never set to true before, which causes the executor will not really be shut down. In case it will be set, it shutdowns as expected, and I don't see any side effects.

This is a follow-up from reported issue #118.