### PR TITLE
add for gcc more clear namespace

### DIFF
--- a/include/concurrencpp/runtime/runtime.h
+++ b/include/concurrencpp/runtime/runtime.h
@@ -42,14 +42,14 @@ namespace concurrencpp {
     class CRCPP_API runtime {
 
        private:
-        std::shared_ptr<inline_executor> m_inline_executor;
-        std::shared_ptr<thread_pool_executor> m_thread_pool_executor;
-        std::shared_ptr<thread_pool_executor> m_background_executor;
-        std::shared_ptr<thread_executor> m_thread_executor;
+        std::shared_ptr<concurrencpp::inline_executor> m_inline_executor;
+        std::shared_ptr<concurrencpp::thread_pool_executor> m_thread_pool_executor;
+        std::shared_ptr<concurrencpp::thread_pool_executor> m_background_executor;
+        std::shared_ptr<concurrencpp::thread_executor> m_thread_executor;
 
         details::executor_collection m_registered_executors;
 
-        std::shared_ptr<timer_queue> m_timer_queue;
+        std::shared_ptr<concurrencpp::timer_queue> m_timer_queue;
 
        public:
         runtime();


### PR DESCRIPTION
I know gcc is not supported yet. But we want to support it in an experimental state, or we already doing it and for that, I patch concurrencpp. To make my life a little bit easier for the next release, I would be happy to see this part of the code.