### PR TITLE
lock-free shared_result

### DIFF
--- a/include/concurrencpp/results/impl/consumer_context.h
+++ b/include/concurrencpp/results/impl/consumer_context.h
@@ -51,7 +51,7 @@ namespace concurrencpp::details {
             coroutine_handle<void> caller_handle;
             std::shared_ptr<std::binary_semaphore> wait_for_ctx;
             std::shared_ptr<when_any_context> when_any_ctx;
-            shared_result_state_base* shared_ctx;
+            std::shared_ptr<shared_result_state_base> shared_ctx;
 
             storage() noexcept {}
             ~storage() noexcept {}
@@ -72,7 +72,7 @@ namespace concurrencpp::details {
         void set_await_handle(coroutine_handle<void> caller_handle) noexcept;
         void set_wait_for_context(const std::shared_ptr<std::binary_semaphore>& wait_ctx) noexcept;
         void set_when_any_context(const std::shared_ptr<when_any_context>& when_any_ctx) noexcept;
-        void set_shared_context(shared_result_state_base& shared_ctx) noexcept;
+        void set_shared_context(std::shared_ptr<shared_result_state_base> shared_ctx) noexcept;
     };
 }  // namespace concurrencpp::details
 

--- a/include/concurrencpp/results/impl/consumer_context.h
+++ b/include/concurrencpp/results/impl/consumer_context.h
@@ -72,7 +72,7 @@ namespace concurrencpp::details {
         void set_await_handle(coroutine_handle<void> caller_handle) noexcept;
         void set_wait_for_context(const std::shared_ptr<std::binary_semaphore>& wait_ctx) noexcept;
         void set_when_any_context(const std::shared_ptr<when_any_context>& when_any_ctx) noexcept;
-        void set_shared_context(std::shared_ptr<shared_result_state_base> shared_ctx) noexcept;
+        void set_shared_context(const std::shared_ptr<shared_result_state_base>& shared_ctx) noexcept;
     };
 }  // namespace concurrencpp::details
 

--- a/include/concurrencpp/results/impl/consumer_context.h
+++ b/include/concurrencpp/results/impl/consumer_context.h
@@ -45,12 +45,13 @@ namespace concurrencpp::details {
     class CRCPP_API consumer_context {
 
        private:
-        enum class consumer_status { idle, await, wait_for, when_any };
+        enum class consumer_status { idle, await, wait_for, when_any, shared };
 
         union storage {
             coroutine_handle<void> caller_handle;
             std::shared_ptr<std::binary_semaphore> wait_for_ctx;
             std::shared_ptr<when_any_context> when_any_ctx;
+            shared_result_state_base* shared_ctx;
 
             storage() noexcept {}
             ~storage() noexcept {}
@@ -71,6 +72,7 @@ namespace concurrencpp::details {
         void set_await_handle(coroutine_handle<void> caller_handle) noexcept;
         void set_wait_for_context(const std::shared_ptr<std::binary_semaphore>& wait_ctx) noexcept;
         void set_when_any_context(const std::shared_ptr<when_any_context>& when_any_ctx) noexcept;
+        void set_shared_context(shared_result_state_base& shared_ctx) noexcept;
     };
 }  // namespace concurrencpp::details
 

--- a/include/concurrencpp/results/impl/producer_context.h
+++ b/include/concurrencpp/results/impl/producer_context.h
@@ -46,35 +46,6 @@ namespace concurrencpp::details {
             }
         }
 
-        producer_context& operator=(producer_context&& rhs) noexcept {
-            assert(m_status == result_status::idle);
-            m_status = std::exchange(rhs.m_status, result_status::idle);
-
-            switch (m_status) {
-                case result_status::value: {
-                    new (std::addressof(m_storage.object)) type(std::move(rhs.m_storage.object));
-                    rhs.m_storage.object.~type();
-                    break;
-                }
-
-                case result_status::exception: {
-                    new (std::addressof(m_storage.exception)) std::exception_ptr(rhs.m_storage.exception);
-                    rhs.m_storage.exception.~exception_ptr();
-                    break;
-                }
-
-                case result_status::idle: {
-                    break;
-                }
-
-                default: {
-                    assert(false);
-                }
-            }
-
-            return *this;
-        }
-
         template<class... argument_types>
         void build_result(argument_types&&... arguments) noexcept(noexcept(type(std::forward<argument_types>(arguments)...))) {
             assert(m_status == result_status::idle);

--- a/include/concurrencpp/results/impl/result_state.h
+++ b/include/concurrencpp/results/impl/result_state.h
@@ -27,7 +27,7 @@ namespace concurrencpp::details {
         bool await(coroutine_handle<void> caller_handle) noexcept;
         pc_state when_any(const std::shared_ptr<when_any_context>& when_any_state) noexcept;
 
-        void share(std::shared_ptr<shared_result_state_base> shared_result_state) noexcept;
+        void share(const std::shared_ptr<shared_result_state_base>& shared_result_state) noexcept;
 
         void try_rewind_consumer() noexcept;
     };

--- a/include/concurrencpp/results/impl/result_state.h
+++ b/include/concurrencpp/results/impl/result_state.h
@@ -27,7 +27,7 @@ namespace concurrencpp::details {
         bool await(coroutine_handle<void> caller_handle) noexcept;
         pc_state when_any(const std::shared_ptr<when_any_context>& when_any_state) noexcept;
 
-        void share(shared_result_state_base& shared_result_state) noexcept;
+        void share(std::shared_ptr<shared_result_state_base> shared_result_state) noexcept;
 
         void try_rewind_consumer() noexcept;
     };

--- a/include/concurrencpp/results/impl/result_state.h
+++ b/include/concurrencpp/results/impl/result_state.h
@@ -27,6 +27,8 @@ namespace concurrencpp::details {
         bool await(coroutine_handle<void> caller_handle) noexcept;
         pc_state when_any(const std::shared_ptr<when_any_context>& when_any_state) noexcept;
 
+        void share(shared_result_state_base& shared_result_state) noexcept;
+
         void try_rewind_consumer() noexcept;
     };
 
@@ -144,6 +146,11 @@ namespace concurrencpp::details {
         type get() {
             assert_done();
             return m_producer.get();
+        }
+
+        std::add_lvalue_reference_t<type> get_ref() {
+            assert_done();
+            return m_producer.get_ref();
         }
 
         template<class callable_type>

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -78,7 +78,8 @@ namespace concurrencpp::details {
         template<class clock, class duration>
         result_status wait_until(const std::chrono::time_point<clock, duration>& timeout_time) {
             while ((status() == result_status::idle) && (clock::now() < timeout_time)) {
-                m_semaphore.try_acquire_until(timeout_time);
+                const auto res = m_semaphore.try_acquire_until(timeout_time);
+                (void)res;
             }
 
             return status();

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -57,7 +57,7 @@ namespace concurrencpp::details {
             m_result_state.reset();
         }
 
-        void share(const std::shared_ptr<result_state_base>& self) noexcept {
+        void share(const std::shared_ptr<shared_result_state_base>& self) noexcept {
             assert(static_cast<bool>(m_result_state));
             m_result_state->share(self);
         }

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -1,6 +1,7 @@
 #ifndef CONCURRENCPP_SHARED_RESULT_STATE_H
 #define CONCURRENCPP_SHARED_RESULT_STATE_H
 
+#include "concurrencpp/platform_defs.h"
 #include "concurrencpp/results/impl/result_state.h"
 
 #include <atomic>

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -24,10 +24,8 @@ namespace concurrencpp::details {
     class CRCPP_API shared_result_state_base {
 
        protected:
-        static constexpr std::ptrdiff_t k_max_waiters = std::numeric_limits<std::ptrdiff_t>::max();
-
         std::atomic<shared_await_context*> m_awaiters {nullptr};
-        std::counting_semaphore<k_max_waiters> m_semaphore {0};
+        std::counting_semaphore<> m_semaphore {0};
 
         static shared_await_context* result_ready_constant() noexcept;
         bool result_ready() const noexcept;

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -89,7 +89,7 @@ namespace concurrencpp::details {
         }
 
         void on_result_finished() noexcept override {
-            m_status.store(m_result_state->status(), std::memory_order_relaxed);
+            m_status.store(m_result_state->status(), std::memory_order_release);
 
             auto k_result_ready = result_ready_constant();
             auto awaiters = m_awaiters.exchange(k_result_ready, std::memory_order_acq_rel);

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -1,167 +1,92 @@
 #ifndef CONCURRENCPP_SHARED_RESULT_STATE_H
 #define CONCURRENCPP_SHARED_RESULT_STATE_H
 
-#include "concurrencpp/coroutines/coroutine.h"
-#include "concurrencpp/forward_declarations.h"
-#include "concurrencpp/results/impl/producer_context.h"
-#include "concurrencpp/results/impl/return_value_struct.h"
+#include "concurrencpp/results/impl/result_state.h"
 
 #include <atomic>
-#include <mutex>
-#include <optional>
-#include <condition_variable>
+#include <semaphore>
 
 #include <cassert>
 
 namespace concurrencpp::details {
-    struct shared_await_context {
+    struct shared_result_helper {
+        template<class type>
+        static consumer_result_state_ptr<type> get_state(result<type>& result) noexcept {
+            return std::move(result.m_state);
+        }
+    };
+
+    struct CRCPP_API shared_await_context {
         shared_await_context* next = nullptr;
         coroutine_handle<void> caller_handle;
     };
-}  // namespace concurrencpp::details
 
-namespace concurrencpp::details {
     class CRCPP_API shared_result_state_base {
 
        protected:
-        std::atomic_bool m_ready {false};
-        mutable std::mutex m_lock;
-        shared_await_context* m_awaiters = nullptr;
-        std::optional<std::condition_variable> m_condition;
+        static constexpr shared_await_context* k_result_ready = reinterpret_cast<shared_await_context*>(-1);
+        static constexpr std::ptrdiff_t k_max_waiters = std::numeric_limits<std::ptrdiff_t>::max();
 
-        void await_impl(std::unique_lock<std::mutex>& lock, shared_await_context& awaiter) noexcept;
-        void wait_impl(std::unique_lock<std::mutex>& lock);
-        bool wait_for_impl(std::unique_lock<std::mutex>& lock, std::chrono::milliseconds ms);
+        std::atomic<shared_await_context*> m_awaiters {nullptr};
+        std::counting_semaphore<k_max_waiters> m_semaphore {0};
 
        public:
-        void complete_producer();
-        bool await(shared_await_context& awaiter);
-        void wait();
+        bool await(shared_await_context& awaiter) noexcept;
+
+        void on_result_finished() noexcept;
     };
 
     template<class type>
-    class shared_result_state final : public shared_result_state_base {
+    class CRCPP_API shared_result_state final : public shared_result_state_base {
 
        private:
-        producer_context<type> m_producer;
-
-        void assert_done() const noexcept {
-            assert(m_ready.load(std::memory_order_acquire));
-            assert(m_producer.status() != result_status::idle);
-        }
+        consumer_result_state_ptr<type> m_result_state;
 
        public:
+        shared_result_state(consumer_result_state_ptr<type> result_state) noexcept : m_result_state(std::move(result_state)) {
+            assert(static_cast<bool>(m_result_state));
+            m_result_state->share(*this);
+        }
+
+        ~shared_result_state() noexcept {
+            m_result_state->try_rewind_consumer();
+        }
+
         result_status status() const noexcept {
-            if (!m_ready.load(std::memory_order_acquire)) {
+            if (m_awaiters.load(std::memory_order_acquire) != k_result_ready) {
                 return result_status::idle;
             }
 
-            return m_producer.status();
+            assert(static_cast<bool>(m_result_state));
+            return m_result_state->status();
+        }
+
+        void wait() noexcept {
+            if (status() == result_status::idle) {
+                m_semaphore.acquire();
+            }
         }
 
         template<class duration_unit, class ratio>
         result_status wait_for(std::chrono::duration<duration_unit, ratio> duration) {
-            if (m_ready.load(std::memory_order_acquire)) {
-                return m_producer.status();
-            }
-
-            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration) + std::chrono::milliseconds(1);
-
-            std::unique_lock<std::mutex> lock(m_lock);
-            if (m_ready.load(std::memory_order_acquire)) {
-                return m_producer.status();
-            }
-
-            const auto ready = wait_for_impl(lock, ms);
-            if (ready) {
-                assert_done();
-                return m_producer.status();
-            }
-
-            lock.unlock();
-            return result_status::idle;
+            const auto time_point = std::chrono::system_clock::now() + duration;
+            return wait_until(time_point);
         }
 
         template<class clock, class duration>
         result_status wait_until(const std::chrono::time_point<clock, duration>& timeout_time) {
-            const auto now = clock::now();
-            if (timeout_time <= now) {
-                return status();
+            while (status() == result_status::idle && clock::now() < timeout_time) {
+                m_semaphore.try_acquire_until(timeout_time);
             }
 
-            const auto diff = timeout_time - now;
-            return wait_for(diff);
+            return status();
         }
 
         std::add_lvalue_reference_t<type> get() {
-            return m_producer.get_ref();
-        }
-
-        template<class... argument_types>
-        void set_result(argument_types&&... arguments) noexcept(noexcept(type(std::forward<argument_types>(arguments)...))) {
-            m_producer.build_result(std::forward<argument_types>(arguments)...);
-        }
-
-        void unhandled_exception() noexcept {
-            m_producer.build_exception(std::current_exception());
+            assert(static_cast<bool>(m_result_state));
+            return m_result_state->get_ref();
         }
     };
 }  // namespace concurrencpp::details
-
-namespace concurrencpp::details {
-    struct shared_result_publisher : public suspend_always {
-        template<class promise_type>
-        bool await_suspend(coroutine_handle<promise_type> handle) const noexcept {
-            // TODO : this can (very rarely) throw, but the standard mandates us to have a noexcept finalizer
-            handle.promise().complete_producer();
-            return false;
-        }
-    };
-
-    template<class type>
-    class shared_result_promise : public return_value_struct<shared_result_promise<type>, type> {
-
-       private:
-        const std::shared_ptr<shared_result_state<type>> m_state = std::make_shared<shared_result_state<type>>();
-
-       public:
-        template<class... argument_types>
-        void set_result(argument_types&&... arguments) noexcept(noexcept(type(std::forward<argument_types>(arguments)...))) {
-            m_state->set_result(std::forward<argument_types>(arguments)...);
-        }
-
-        void unhandled_exception() const noexcept {
-            m_state->unhandled_exception();
-        }
-
-        shared_result<type> get_return_object() noexcept {
-            return shared_result<type> {m_state};
-        }
-
-        suspend_never initial_suspend() const noexcept {
-            return {};
-        }
-
-        shared_result_publisher final_suspend() const noexcept {
-            return {};
-        }
-
-        void complete_producer() const {
-            m_state->complete_producer();
-        }
-    };
-
-    struct shared_result_tag {};
-}  // namespace concurrencpp::details
-
-namespace CRCPP_COROUTINE_NAMESPACE {
-    // No executor + No result
-    template<class type>
-    struct coroutine_traits<::concurrencpp::shared_result<type>,
-                            concurrencpp::details::shared_result_tag,
-                            concurrencpp::result<type>> {
-        using promise_type = concurrencpp::details::shared_result_promise<type>;
-    };
-}  // namespace CRCPP_COROUTINE_NAMESPACE
 
 #endif

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -24,12 +24,12 @@ namespace concurrencpp::details {
     class CRCPP_API shared_result_state_base {
 
        protected:
-        static constexpr shared_await_context* k_result_ready = reinterpret_cast<shared_await_context*>(-1);
         static constexpr std::ptrdiff_t k_max_waiters = std::numeric_limits<std::ptrdiff_t>::max();
 
         std::atomic<shared_await_context*> m_awaiters {nullptr};
         std::counting_semaphore<k_max_waiters> m_semaphore {0};
 
+        static shared_await_context* result_ready_constant() noexcept;
         bool result_ready() const noexcept;
 
        public:
@@ -81,7 +81,8 @@ namespace concurrencpp::details {
                 m_semaphore.try_acquire_until(timeout_time);
             }
 
-            return status();
+            assert(static_cast<bool>(m_result_state));
+            return m_result_state->status();
         }
 
         std::add_lvalue_reference_t<type> get() {

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -49,12 +49,17 @@ namespace concurrencpp::details {
        public:
         shared_result_state(consumer_result_state_ptr<type> result_state) noexcept : m_result_state(std::move(result_state)) {
             assert(static_cast<bool>(m_result_state));
-            m_result_state->share(*this);
         }
 
         ~shared_result_state() noexcept {
             assert(static_cast<bool>(m_result_state));
             m_result_state->try_rewind_consumer();
+            m_result_state.reset();
+        }
+
+        void share(const std::shared_ptr<result_state_base>& self) noexcept {
+            assert(static_cast<bool>(m_result_state));
+            m_result_state->share(self);
         }
 
         void wait() noexcept {

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -108,8 +108,9 @@ namespace concurrencpp::details {
 
             while (awaiters != nullptr) {
                 assert(static_cast<bool>(awaiters->caller_handle));
-                awaiters->caller_handle();
+                auto caller_handle = awaiters->caller_handle;
                 awaiters = awaiters->next;
+                caller_handle();
             }
 
             /* theoretically buggish, practically there's no way

--- a/include/concurrencpp/results/shared_result.h
+++ b/include/concurrencpp/results/shared_result.h
@@ -12,10 +12,6 @@ namespace concurrencpp {
        private:
         std::shared_ptr<details::shared_result_state<type>> m_state;
 
-        static shared_result<type> make_shared_result(details::shared_result_tag, result<type> result) {
-            co_return co_await result;
-        }
-
         void throw_if_empty(const char* message) const {
             if (!static_cast<bool>(m_state)) {
                 throw errors::empty_result(message);
@@ -33,7 +29,7 @@ namespace concurrencpp {
                 return;
             }
 
-            *this = make_shared_result({}, std::move(rhs));
+            m_state = std::make_shared<details::shared_result_state<type>>(details::shared_result_helper::get_state(rhs));
         }
 
         shared_result(const shared_result& rhs) noexcept = default;

--- a/include/concurrencpp/results/shared_result.h
+++ b/include/concurrencpp/results/shared_result.h
@@ -32,6 +32,7 @@ namespace concurrencpp {
             }
 
             m_state = std::make_shared<details::shared_result_state<type>>(details::shared_result_helper::get_state(rhs));
+            m_state->share(std::static_pointer_cast<details::shared_result_state_base>(m_state));
         }
 
         shared_result(const shared_result& rhs) noexcept = default;

--- a/include/concurrencpp/results/shared_result.h
+++ b/include/concurrencpp/results/shared_result.h
@@ -22,7 +22,9 @@ namespace concurrencpp {
         shared_result() noexcept = default;
         ~shared_result() noexcept = default;
 
-        shared_result(std::shared_ptr<details::shared_result_state<type>> state) noexcept : m_state(std::move(state)) {}
+        shared_result(std::shared_ptr<details::shared_result_state<type>> state) noexcept : m_state(std::move(state)) {
+            m_state->share(std::static_pointer_cast<details::shared_result_state_base>(m_state));
+        }
 
         shared_result(result<type> rhs) {
             if (!static_cast<bool>(rhs)) {

--- a/include/concurrencpp/results/shared_result.h
+++ b/include/concurrencpp/results/shared_result.h
@@ -22,9 +22,7 @@ namespace concurrencpp {
         shared_result() noexcept = default;
         ~shared_result() noexcept = default;
 
-        shared_result(std::shared_ptr<details::shared_result_state<type>> state) noexcept : m_state(std::move(state)) {
-            m_state->share(std::static_pointer_cast<details::shared_result_state_base>(m_state));
-        }
+        shared_result(std::shared_ptr<details::shared_result_state<type>> state) noexcept : m_state(std::move(state)) {}
 
         shared_result(result<type> rhs) {
             if (!static_cast<bool>(rhs)) {

--- a/include/concurrencpp/results/shared_result.h
+++ b/include/concurrencpp/results/shared_result.h
@@ -7,7 +7,7 @@
 
 namespace concurrencpp {
     template<class type>
-    class CRCPP_API shared_result {
+    class shared_result {
 
        private:
         std::shared_ptr<details::shared_result_state<type>> m_state;

--- a/include/concurrencpp/results/shared_result.h
+++ b/include/concurrencpp/results/shared_result.h
@@ -7,7 +7,7 @@
 
 namespace concurrencpp {
     template<class type>
-    class shared_result {
+    class CRCPP_API shared_result {
 
        private:
         std::shared_ptr<details::shared_result_state<type>> m_state;

--- a/include/concurrencpp/results/shared_result_awaitable.h
+++ b/include/concurrencpp/results/shared_result_awaitable.h
@@ -5,7 +5,7 @@
 
 namespace concurrencpp::details {
     template<class type>
-    class shared_awaitable_base : public suspend_always {
+    class CRCPP_API shared_awaitable_base : public suspend_always {
        protected:
         std::shared_ptr<shared_result_state<type>> m_state;
 
@@ -19,7 +19,7 @@ namespace concurrencpp::details {
 
 namespace concurrencpp {
     template<class type>
-    class shared_awaitable : public details::shared_awaitable_base<type> {
+    class CRCPP_API shared_awaitable : public details::shared_awaitable_base<type> {
 
        private:
         details::shared_await_context m_await_ctx;
@@ -40,7 +40,7 @@ namespace concurrencpp {
     };
 
     template<class type>
-    class shared_resolve_awaitable : public details::shared_awaitable_base<type> {
+    class CRCPP_API shared_resolve_awaitable : public details::shared_awaitable_base<type> {
 
        private:
         details::shared_await_context m_await_ctx;

--- a/include/concurrencpp/results/shared_result_awaitable.h
+++ b/include/concurrencpp/results/shared_result_awaitable.h
@@ -5,7 +5,8 @@
 
 namespace concurrencpp::details {
     template<class type>
-    class CRCPP_API shared_awaitable_base : public suspend_always {
+    class shared_awaitable_base : public suspend_always {
+       
        protected:
         std::shared_ptr<shared_result_state<type>> m_state;
 
@@ -19,7 +20,7 @@ namespace concurrencpp::details {
 
 namespace concurrencpp {
     template<class type>
-    class CRCPP_API shared_awaitable : public details::shared_awaitable_base<type> {
+    class shared_awaitable : public details::shared_awaitable_base<type> {
 
        private:
         details::shared_await_context m_await_ctx;
@@ -40,7 +41,7 @@ namespace concurrencpp {
     };
 
     template<class type>
-    class CRCPP_API shared_resolve_awaitable : public details::shared_awaitable_base<type> {
+    class shared_resolve_awaitable : public details::shared_awaitable_base<type> {
 
        private:
         details::shared_await_context m_await_ctx;

--- a/source/results/impl/consumer_context.cpp
+++ b/source/results/impl/consumer_context.cpp
@@ -200,11 +200,10 @@ void consumer_context::set_when_any_context(const std::shared_ptr<when_any_conte
     details::build(m_storage.when_any_ctx, when_any_ctx);
 }
 
-void concurrencpp::details::consumer_context::set_shared_context(
-    shared_result_state_base& shared_ctx) noexcept {
+void concurrencpp::details::consumer_context::set_shared_context(std::shared_ptr<shared_result_state_base> shared_ctx) noexcept {
     assert(m_status == consumer_status::idle);
     m_status = consumer_status::shared;
-    details::build(m_storage.shared_ctx, &shared_ctx);
+    details::build(m_storage.shared_ctx, shared_ctx);
 }
 
 void consumer_context::resume_consumer(result_state_base& self) const {

--- a/source/results/impl/consumer_context.cpp
+++ b/source/results/impl/consumer_context.cpp
@@ -200,7 +200,7 @@ void consumer_context::set_when_any_context(const std::shared_ptr<when_any_conte
     details::build(m_storage.when_any_ctx, when_any_ctx);
 }
 
-void concurrencpp::details::consumer_context::set_shared_context(std::shared_ptr<shared_result_state_base> shared_ctx) noexcept {
+void concurrencpp::details::consumer_context::set_shared_context(const std::shared_ptr<shared_result_state_base>& shared_ctx) noexcept {
     assert(m_status == consumer_status::idle);
     m_status = consumer_status::shared;
     details::build(m_storage.shared_ctx, shared_ctx);

--- a/source/results/impl/consumer_context.cpp
+++ b/source/results/impl/consumer_context.cpp
@@ -1,6 +1,7 @@
 #include "concurrencpp/results/impl/consumer_context.h"
 
 #include "concurrencpp/executors/executor.h"
+#include "concurrencpp/results/impl/shared_result_state.h"
 
 using concurrencpp::details::when_any_context;
 using concurrencpp::details::consumer_context;
@@ -167,6 +168,10 @@ void consumer_context::destroy() noexcept {
         case consumer_status::when_any: {
             return details::destroy(m_storage.when_any_ctx);
         }
+
+        case consumer_status::shared: {
+            return details::destroy(m_storage.shared_ctx);
+        }
     }
 
     assert(false);
@@ -195,6 +200,13 @@ void consumer_context::set_when_any_context(const std::shared_ptr<when_any_conte
     details::build(m_storage.when_any_ctx, when_any_ctx);
 }
 
+void concurrencpp::details::consumer_context::set_shared_context(
+    shared_result_state_base& shared_ctx) noexcept {
+    assert(m_status == consumer_status::idle);
+    m_status = consumer_status::shared;
+    details::build(m_storage.shared_ctx, &shared_ctx);
+}
+
 void consumer_context::resume_consumer(result_state_base& self) const {
     switch (m_status) {
         case consumer_status::idle: {
@@ -217,6 +229,11 @@ void consumer_context::resume_consumer(result_state_base& self) const {
         case consumer_status::when_any: {
             const auto when_any_ctx = m_storage.when_any_ctx;
             return when_any_ctx->try_resume(self);
+        }
+
+        case consumer_status::shared: {
+            const auto shared_ctx = m_storage.shared_ctx;
+            return shared_ctx->on_result_finished();
         }
     }
 

--- a/source/results/impl/result_state.cpp
+++ b/source/results/impl/result_state.cpp
@@ -77,6 +77,28 @@ result_state_base::pc_state result_state_base::when_any(const std::shared_ptr<wh
     return state;
 }
 
+void concurrencpp::details::result_state_base::share(shared_result_state_base& shared_result_state) noexcept {
+    const auto state = m_pc_state.load(std::memory_order_acquire);
+    if (state == pc_state::producer_done) {
+        return shared_result_state.on_result_finished();
+    }
+
+    m_consumer.set_shared_context(shared_result_state);
+
+    auto expected_state = pc_state::idle;
+    const auto idle = m_pc_state.compare_exchange_strong(expected_state,
+                                                         pc_state::consumer_set,
+                                                         std::memory_order_acq_rel,
+                                                         std::memory_order_acquire);
+
+    if (idle) {
+        return;
+    }
+
+    assert_done();
+    shared_result_state.on_result_finished();
+}
+
 void result_state_base::try_rewind_consumer() noexcept {
     const auto pc_state = m_pc_state.load(std::memory_order_acquire);
     if (pc_state != pc_state::consumer_set) {

--- a/source/results/impl/result_state.cpp
+++ b/source/results/impl/result_state.cpp
@@ -77,7 +77,7 @@ result_state_base::pc_state result_state_base::when_any(const std::shared_ptr<wh
     return state;
 }
 
-void concurrencpp::details::result_state_base::share(std::shared_ptr<shared_result_state_base> shared_result_state) noexcept {
+void concurrencpp::details::result_state_base::share(const std::shared_ptr<shared_result_state_base>& shared_result_state) noexcept {
     const auto state = m_pc_state.load(std::memory_order_acquire);
     if (state == pc_state::producer_done) {
         return shared_result_state->on_result_finished();

--- a/source/results/impl/result_state.cpp
+++ b/source/results/impl/result_state.cpp
@@ -77,10 +77,10 @@ result_state_base::pc_state result_state_base::when_any(const std::shared_ptr<wh
     return state;
 }
 
-void concurrencpp::details::result_state_base::share(shared_result_state_base& shared_result_state) noexcept {
+void concurrencpp::details::result_state_base::share(std::shared_ptr<shared_result_state_base> shared_result_state) noexcept {
     const auto state = m_pc_state.load(std::memory_order_acquire);
     if (state == pc_state::producer_done) {
-        return shared_result_state.on_result_finished();
+        return shared_result_state->on_result_finished();
     }
 
     m_consumer.set_shared_context(shared_result_state);
@@ -96,7 +96,7 @@ void concurrencpp::details::result_state_base::share(shared_result_state_base& s
     }
 
     assert_done();
-    shared_result_state.on_result_finished();
+    shared_result_state->on_result_finished();
 }
 
 void result_state_base::try_rewind_consumer() noexcept {

--- a/source/results/impl/shared_result_state.cpp
+++ b/source/results/impl/shared_result_state.cpp
@@ -7,7 +7,7 @@ concurrencpp::details::shared_await_context* shared_result_state_base::result_re
 }
 
 concurrencpp::result_status concurrencpp::details::shared_result_state_base::status() const noexcept {
-    return m_status.load(std::memory_order_relaxed);
+    return m_status.load(std::memory_order_acquire);
 }
 
 bool shared_result_state_base::await(shared_await_context& awaiter) noexcept {

--- a/source/results/impl/shared_result_state.cpp
+++ b/source/results/impl/shared_result_state.cpp
@@ -24,3 +24,9 @@ bool shared_result_state_base::await(shared_await_context& awaiter) noexcept {
         }
     }
 }
+
+void concurrencpp::details::shared_result_state_base::wait() noexcept {
+    if (status() == result_status::idle) {
+        m_semaphore.acquire();
+    }
+}

--- a/source/results/impl/shared_result_state.cpp
+++ b/source/results/impl/shared_result_state.cpp
@@ -6,7 +6,7 @@ concurrencpp::details::shared_await_context* shared_result_state_base::result_re
     return reinterpret_cast<shared_await_context*>(-1);
 }
 
-bool concurrencpp::details::shared_result_state_base::result_ready() const noexcept {
+bool shared_result_state_base::result_ready() const noexcept {
     return m_awaiters.load(std::memory_order_acquire) == result_ready_constant();
 }
 
@@ -51,5 +51,5 @@ void shared_result_state_base::on_result_finished() noexcept {
        that we'll have more than max(ptrdiff_t) / 2 waiters.
        on 64 bits, that's 2^62 waiters, on 32 bits thats 2^30 waiters.
     */
-    m_semaphore.release(k_max_waiters / 2);
+    m_semaphore.release(m_semaphore.max() / 2);
 }

--- a/source/results/impl/shared_result_state.cpp
+++ b/source/results/impl/shared_result_state.cpp
@@ -27,6 +27,6 @@ bool shared_result_state_base::await(shared_await_context& awaiter) noexcept {
 
 void concurrencpp::details::shared_result_state_base::wait() noexcept {
     if (status() == result_status::idle) {
-        m_semaphore.acquire();
+        m_status.wait(result_status::idle, std::memory_order_acquire);
     }
 }


### PR DESCRIPTION
note: on clang version below 13 (11,12), there is a huge performance penalty.
It appears that `counting_semaphore::release(n)` has execution time linear to `n`, and when we try to release `counting_semaphore::max() / 2` waiters, this can take up to dozens seconds.
However, `shared_result` is not a popular type to begin with, and on the longer run when older clang versions will not be used this  refactor will definitely reduce execution time.