### PR TITLE
fix tests compilation error with latest stdlibc++ on linux

### DIFF
--- a/test/include/infra/assertions.h
+++ b/test/include/infra/assertions.h
@@ -1,6 +1,7 @@
 #ifndef CONCURRENCPP_ASSERTIONS_H
 #define CONCURRENCPP_ASSERTIONS_H
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
Fixes the libraries tests failing to compile on arch linux with latest stdlibc++ due to a missing include for `intptr_t` in "test/include/infra/assertions.h", this is also broken in master.