### PR TITLE
Fix build failure on mingw with gcc #132

### DIFF
--- a/include/concurrencpp/platform_defs.h
+++ b/include/concurrencpp/platform_defs.h
@@ -1,7 +1,9 @@
 #ifndef CONCURRENCPP_PLATFORM_DEFS_H
 #define CONCURRENCPP_PLATFORM_DEFS_H
 
-#if defined(_WIN32)
+#if defined(__MINGW32__)
+#    define CRCPP_MINGW_OS
+#elif defined(_WIN32)
 #    define CRCPP_WIN_OS
 #elif defined(unix) || defined(__unix__) || defined(__unix)
 #    define CRCPP_UNIX_OS

--- a/source/threads/thread.cpp
+++ b/source/threads/thread.cpp
@@ -54,6 +54,14 @@ void thread::set_name(std::string_view name) noexcept {
     ::SetThreadDescription(::GetCurrentThread(), utf16_name.data());
 }
 
+#elif defined(CRCPP_MINGW_OS)
+
+#    include <pthread.h>
+
+void thread::set_name(std::string_view name) noexcept {
+    ::pthread_setname_np(::pthread_self(), name.data());
+}
+
 #elif defined(CRCPP_UNIX_OS)
 
 #    include <pthread.h>


### PR DESCRIPTION
This adds a new macro in `platform_defs.h` for MinGW and then uses that in `thread.cpp` to select the winpthread version in `thread::setname`