### PR TITLE
fix build when compiling with Werror

### DIFF
--- a/source/timers/timer_queue.cpp
+++ b/source/timers/timer_queue.cpp
@@ -148,9 +148,10 @@ namespace concurrencpp::details {
 timer_queue::timer_queue(milliseconds max_waiting_time,
                          const std::function<void(std::string_view thread_name)>& thread_started_callback,
                          const std::function<void(std::string_view thread_name)>& thread_terminated_callback) :
+    m_atomic_abort(false), m_abort(false), m_idle(true),
+    m_max_waiting_time(max_waiting_time),
     m_thread_started_callback(thread_started_callback),
-    m_thread_terminated_callback(thread_terminated_callback), m_atomic_abort(false), m_abort(false), m_idle(true),
-    m_max_waiting_time(max_waiting_time) {}
+    m_thread_terminated_callback(thread_terminated_callback) {}
 
 timer_queue::~timer_queue() noexcept {
     shutdown();


### PR DESCRIPTION
Compilation was failing on clang16 when compiling with Werror, specifically Wreorder-ctor, this makes sense because of initilization rules in C++, where the order of intialization matters.


m_thread_thread_start_callback & m_thread_terminated_callback are now initialized at the end of the initialization chain in timer_queue's constructor in accordance with the declaration of the header file.