### PR TITLE
Fixed bug for old versions of Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ set_target_properties(concurrencpp PROPERTIES
         SOVERSION "${PROJECT_VERSION_MAJOR}"
 )
 
+set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "d")
+
 target_coroutine_options(concurrencpp)
 
 target_compile_definitions(concurrencpp

--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -5,6 +5,7 @@
 #include "concurrencpp/results/impl/result_state.h"
 
 #include <atomic>
+#include <chrono>
 #include <semaphore>
 
 #include <cassert>

--- a/include/concurrencpp/results/result.h
+++ b/include/concurrencpp/results/result.h
@@ -11,7 +11,7 @@
 
 namespace concurrencpp {
     template<class type>
-    class result {
+    class [[nodiscard]] result {
 
         static constexpr auto valid_result_type_v = std::is_same_v<type, void> || std::is_nothrow_move_constructible_v<type>;
 

--- a/include/concurrencpp/threads/thread.h
+++ b/include/concurrencpp/threads/thread.h
@@ -4,6 +4,7 @@
 #include "concurrencpp/platform_defs.h"
 
 #include <functional>
+#include <string>
 #include <string_view>
 #include <thread>
 

--- a/source/threads/thread.cpp
+++ b/source/threads/thread.cpp
@@ -47,11 +47,17 @@ size_t thread::hardware_concurrency() noexcept {
 #ifdef CRCPP_WIN_OS
 
 #    include <Windows.h>
+#    include <VersionHelpers.h>
 
 void thread::set_name(std::string_view name) noexcept {
     const std::wstring utf16_name(name.begin(),
                                   name.end());  // concurrencpp strings are always ASCII (english only)
-    ::SetThreadDescription(::GetCurrentThread(), utf16_name.data());
+    if (IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 14393)) {
+        // Windows 10 1607 or greater, use SetThreadDescription
+        ::SetThreadDescription(::GetCurrentThread(), utf16_name.c_str());
+    } else {
+        // Windows version is less than Windows 10, do nothing
+    }
 }
 
 #elif defined(CRCPP_MINGW_OS)

--- a/source/threads/thread.cpp
+++ b/source/threads/thread.cpp
@@ -50,10 +50,10 @@ size_t thread::hardware_concurrency() noexcept {
 #    include <VersionHelpers.h>
 
 void thread::set_name(std::string_view name) noexcept {
-    const std::wstring utf16_name(name.begin(),
-                                  name.end());  // concurrencpp strings are always ASCII (english only)
     if (IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 14393)) {
         // Windows 10 1607 or greater, use SetThreadDescription
+        const std::wstring utf16_name(name.begin(),
+                                      name.end());  // concurrencpp strings are always ASCII (english only)
         ::SetThreadDescription(::GetCurrentThread(), utf16_name.c_str());
     } else {
         // Windows version is less than Windows 10, do nothing


### PR DESCRIPTION
Fixes a bug related to the fact that before _Windows 10 version 1607_, the windows api does not have the `::SetThreadDescription` function for setting the name for a thread.
When the application tries to call a system function, it crashes.