### PR TITLE
Fixed MSVC build with CL.exe 19.41.34120

### DIFF
--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <semaphore>
+#include <chrono>
 
 #include <cassert>
 

--- a/include/concurrencpp/threads/thread.h
+++ b/include/concurrencpp/threads/thread.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string_view>
 #include <thread>
+#include <string>
 
 namespace concurrencpp::details {
     class CRCPP_API thread {


### PR DESCRIPTION
`<string>` is no longer automatically included in the various header files thread.h uses when compiling with MSVC/cl.exe. I've explicitly included it now so MSVC/cl.exe builds work again.