### PR TITLE
missing headers added and fixed compile issue on windows

### DIFF
--- a/include/concurrencpp/results/impl/shared_result_state.h
+++ b/include/concurrencpp/results/impl/shared_result_state.h
@@ -6,7 +6,7 @@
 
 #include <atomic>
 #include <semaphore>
-
+#include<chrono>
 #include <cassert>
 
 namespace concurrencpp::details {

--- a/include/concurrencpp/threads/thread.h
+++ b/include/concurrencpp/threads/thread.h
@@ -6,7 +6,7 @@
 #include <functional>
 #include <string_view>
 #include <thread>
-
+#include<string>
 namespace concurrencpp::details {
     class CRCPP_API thread {
 


### PR DESCRIPTION
On Windows  these compile error fixed

```
PS C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master> cmake -B build
-- Building for: Visual Studio 17 2022
-- The CXX compiler identification is MSVC 19.44.35215.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Found Threads: TRUE
-- Configuring done (15.7s)
-- Generating done (0.0s)
-- Build files have been written to: C:/Users/itsvi/Downloads/concurrencpp-master/concurrencpp-master/build
PS C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master> cmake --build build
MSBuild version 17.14.19+164abd434 for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/Users/itsvi/Downloads/concurrencpp-master/concurrencpp-master/CMakeLists.txt
  task.cpp
  executor.cpp
  manual_executor.cpp
  thread_executor.cpp
  thread_pool_executor.cpp
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2039: 'string': is not a member of 's
td' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\thread(37,1):
      see declaration of 'std'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2061: syntax error: identifier 'strin
g' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C3861: 'name': identifier not found [C
:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C3861: 'callable': identifier not foun
d [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C3861: 'thread_started_callback': iden
tifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C3861: 'thread_terminated_callback': i
dentifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C2065: 'name': undeclared identifier [
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C2065: 'callable': undeclared identifi
er [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C2065: 'thread_started_callback': unde
clared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C2065: 'thread_terminated_callback': u
ndeclared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\thread_executor.cpp(21,33): error C2440: '<function-style-cast>': cannot
convert from 'initializer list' to 'concurrencpp::details::thread' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcx
proj]
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\thread_executor.cpp(21,33):
      'concurrencpp::details::thread::thread': function does not take 4 arguments
          C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
          could be 'concurrencpp::details::thread::thread(void)'
          C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\thread_executor.cpp(21,33):
          while trying to match the argument list '(std::string, concurrencpp::thread_executor::enqueue_impl::<lambda_1>, const std::function<void (std::st
  ring_view)>, const std::function<void (std::string_view)>)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2039: 'string': is not a member of 's
td' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\thread(37,1):
      see declaration of 'std'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2061: syntax error: identifier 'strin
g' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C3861: 'name': identifier not found [C
:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C3861: 'callable': identifier not foun
d [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C3861: 'thread_started_callback': iden
tifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C3861: 'thread_terminated_callback': i
dentifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C2065: 'name': undeclared identifier [
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C2065: 'callable': undeclared identifi
er [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C2065: 'thread_started_callback': unde
clared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C2065: 'thread_terminated_callback': u
ndeclared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/thread_pool_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\thread_pool_executor.cpp(396,22): error C2440: '<function-style-cast>': c
annot convert from 'initializer list' to 'concurrencpp::details::thread' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrenc
pp.vcxproj]
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\thread_pool_executor.cpp(396,22):
      'concurrencpp::details::thread::thread': function does not take 4 arguments
          C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
          could be 'concurrencpp::details::thread::thread(void)'
          C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\thread_pool_executor.cpp(396,22):
          while trying to match the argument list '(const std::string, concurrencpp::details::thread_pool_worker::ensure_worker_active::<lambda_1>, const s
  td::function<void (std::string_view)>, const std::function<void (std::string_view)>)'

  worker_thread_executor.cpp
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2039: 'string': is not a member of 's
td' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\thread(37,1):
      see declaration of 'std'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2061: syntax error: identifier 'strin
g' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C3861: 'name': identifier not found [C
:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C3861: 'callable': identifier not foun
d [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C3861: 'thread_started_callback': iden
tifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C3861: 'thread_terminated_callback': i
dentifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C2065: 'name': undeclared identifier [
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C2065: 'callable': undeclared identifi
er [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C2065: 'thread_started_callback': unde
clared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C2065: 'thread_terminated_callback': u
ndeclared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/executors/worker_thread_executor.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\worker_thread_executor.cpp(18,31): error C2440: '<function-style-cast>':
cannot convert from 'initializer list' to 'concurrencpp::details::thread' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurren
cpp.vcxproj]
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\worker_thread_executor.cpp(18,31):
      'concurrencpp::details::thread::thread': function does not take 4 arguments
          C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
          could be 'concurrencpp::details::thread::thread(void)'
          C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\executors\worker_thread_executor.cpp(18,31):
          while trying to match the argument list '(std::string, concurrencpp::worker_thread_executor::make_os_worker_thread::<lambda_1>, const std::functi
  on<void (std::string_view)>, const std::function<void (std::string_view)>)'

  consumer_context.cpp
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\results\impl\shared_result_state.h(47,50): error C2039: 'system_clock
': is not a member of 'std::chrono' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/results/impl/consumer_context.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\__msvc_chrono.hpp(286,11):
      see declaration of 'std::chrono'
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\results\impl\shared_result_state.h(46,23):
      This diagnostic occurred in the compiler generated function 'concurrencpp::result_status concurrencpp::details::shared_result_state_base::wait_for(st
  d::chrono::duration<_Rep,_Period>)'

  result_state.cpp
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\results\impl\shared_result_state.h(47,50): error C2039: 'system_clock
': is not a member of 'std::chrono' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/results/impl/result_state.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\__msvc_chrono.hpp(286,11):
      see declaration of 'std::chrono'
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\results\impl\shared_result_state.h(46,23):
      This diagnostic occurred in the compiler generated function 'concurrencpp::result_status concurrencpp::details::shared_result_state_base::wait_for(st
  d::chrono::duration<_Rep,_Period>)'

  shared_result_state.cpp
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\results\impl\shared_result_state.h(47,50): error C2039: 'system_clock
': is not a member of 'std::chrono' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/results/impl/shared_result_state.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\__msvc_chrono.hpp(286,11):
      see declaration of 'std::chrono'
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\results\impl\shared_result_state.h(46,23):
      This diagnostic occurred in the compiler generated function 'concurrencpp::result_status concurrencpp::details::shared_result_state_base::wait_for(st
  d::chrono::duration<_Rep,_Period>)'

  runtime.cpp
  async_lock.cpp
  async_condition_variable.cpp
  thread.cpp
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2039: 'string': is not a member of 's
td' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\thread(37,1):
      see declaration of 'std'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,21): error C2061: syntax error: identifier 'strin
g' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C3861: 'name': identifier not found [C
:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C3861: 'callable': identifier not foun
d [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C3861: 'thread_started_callback': iden
tifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C3861: 'thread_terminated_callback': i
dentifier not found [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(27,54): error C2065: 'name': undeclared identifier [
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(28,76): error C2065: 'callable': undeclared identifi
er [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(29,73): error C2065: 'thread_started_callback': unde
clared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(30,76): error C2065: 'thread_terminated_callback': u
ndeclared identifier [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
  (compiling source file '../source/threads/thread.cpp')
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\include\concurrencpp\threads\thread.h(23,9):
      This diagnostic occurred in the compiler generated function 'concurrencpp::details::thread::thread(void)'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(52,16): error C2039: 'wstring': is not a member of 'std' [C:\Use
rs\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include\thread(37,1):
      see declaration of 'std'

C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(52,5): error C4430: missing type specifier - int assumed. Note:
C++ does not support default-int [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(52,24): error C2146: syntax error: missing ';' before identifier
 'utf16_name' [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(52,24): error C3861: 'utf16_name': identifier not found [C:\User
s\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(54,50): error C2065: 'utf16_name': undeclared identifier [C:\Use
rs\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(54,7): error C2660: 'SetThreadDescription': function does not ta
ke 1 arguments [C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\build\concurrencpp.vcxproj]
      C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\processthreadsapi.h(1425,1):
      see declaration of 'SetThreadDescription'
      C:\Users\itsvi\Downloads\concurrencpp-master\concurrencpp-master\source\threads\thread.cpp(54,7):
      while trying to match the argument list '(HANDLE)'

  timer.cpp
  timer_queue.cpp
  Generating Code...
```


```
PS C:\Users\itsvi\Documents\concurrencpp> cmake --build build
MSBuild version 17.14.19+164abd434 for .NET Framework

  1>Checking Build System
  Building Custom Rule C:/Users/itsvi/Documents/concurrencpp/CMakeLists.txt
  task.cpp
  executor.cpp
  manual_executor.cpp
  thread_executor.cpp
  thread_pool_executor.cpp
  worker_thread_executor.cpp
  consumer_context.cpp
  result_state.cpp
  shared_result_state.cpp
  runtime.cpp
  async_lock.cpp
  async_condition_variable.cpp
  thread.cpp
  timer.cpp
  timer_queue.cpp
  Generating Code...
  concurrencpp.vcxproj -> C:\Users\itsvi\Documents\concurrencpp\build\Debug\concurrencpp.lib
  Building Custom Rule C:/Users/itsvi/Documents/concurrencpp/CMakeLists.txt
PS C:\Users\itsvi\Documents\concurrencpp>
```




